### PR TITLE
feat: 저장된 판서 데이터를 Canvas에 다시 그리는(Replay) 뷰어 구현 #30

### DIFF
--- a/pentalk_front/android/app/src/main/AndroidManifest.xml
+++ b/pentalk_front/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,16 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
+            <!--  Deep Link -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="pentalk"
+                    android:host="material" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/pentalk_front/ios/Runner/Info.plist
+++ b/pentalk_front/ios/Runner/Info.plist
@@ -45,5 +45,19 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+
+	<key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleURLName</key>
+            <string>com.example.pentalk</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>pentalk</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/pentalk_front/lib/main.dart
+++ b/pentalk_front/lib/main.dart
@@ -1,16 +1,96 @@
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'dart:async';
 import 'providers/student_session_provider.dart';
 import 'providers/drawing_provider.dart';
+import 'providers/personal_drawing_provider.dart';
 import 'screens/student_home_screen.dart';
+import 'screens/material_detail_screen.dart';
+import 'screens/drawing_screen.dart';
+import 'services/deep_link_service.dart';
+import 'models/student_session_model.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final DeepLinkService _deepLinkService = DeepLinkService();
+  final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
+  StreamSubscription<Uri>? _linkSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _initDeepLinks();
+  }
+
+  /// Deep Link 초기화
+  void _initDeepLinks() {
+    // 1. 앱 시작 시 초기 링크 확인
+    _handleInitialLink();
+
+    // 2. 백그라운드에서 복귀 시 링크 감지
+    _linkSubscription = _deepLinkService.uriLinkStream.listen(
+          (Uri uri) {
+        debugPrint('📱 Received Deep Link: $uri');
+        _handleDeepLink(uri.toString());
+      },
+      onError: (err) {
+        debugPrint('❌ Deep Link error: $err');
+      },
+    );
+  }
+
+  /// 앱 시작 시 초기 링크 처리
+  Future<void> _handleInitialLink() async {
+    try {
+      final initialLink = await _deepLinkService.getInitialLink();
+      if (initialLink != null) {
+        // 앱이 완전히 로드된 후 처리
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _handleDeepLink(initialLink);
+        });
+      }
+    } catch (e) {
+      debugPrint('❌ Failed to handle initial link: $e');
+    }
+  }
+
+  /// Deep Link 처리
+  void _handleDeepLink(String uriString) {
+    final params = _deepLinkService.parseMaterialLink(uriString);
+
+    if (params == null) {
+      debugPrint('⚠️ Invalid Deep Link format');
+      return;
+    }
+
+    final sessionId = params['sessionId']!;
+    final materialId = params['materialId']!;
+
+    // Navigator로 화면 이동
+    _navigatorKey.currentState?.pushNamed(
+      '/material',
+      arguments: {
+        'sessionId': sessionId,
+        'materialId': materialId,
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _linkSubscription?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -18,8 +98,10 @@ class MyApp extends StatelessWidget {
       providers: [
         ChangeNotifierProvider(create: (_) => StudentSessionProvider()),
         ChangeNotifierProvider(create: (_) => DrawingProvider()),
+        ChangeNotifierProvider(create: (_) => PersonalDrawingProvider()),
       ],
       child: MaterialApp(
+        navigatorKey: _navigatorKey,
         title: '하이브리드 교실 - 학생',
         debugShowCheckedModeBanner: false,
         theme: ThemeData(
@@ -35,7 +117,141 @@ class MyApp extends StatelessWidget {
           ),
         ),
         home: const StudentHomeScreen(),
+
+        // Named Routes 정의
+        routes: {
+          '/home': (context) => const StudentHomeScreen(),
+        },
+
+        // Dynamic Routes (Deep Link용)
+        onGenerateRoute: (settings) {
+          // /material 라우트 처리
+          if (settings.name == '/material') {
+            final args = settings.arguments as Map<String, String>?;
+
+            if (args == null) {
+              return null;
+            }
+
+            final sessionId = args['sessionId']!;
+            final materialId = args['materialId']!;
+
+            return MaterialPageRoute(
+              builder: (context) => _MaterialDetailLoader(
+                sessionId: sessionId,
+                materialId: materialId,
+              ),
+            );
+          }
+
+          return null;
+        },
       ),
+    );
+  }
+}
+
+/// ===============================
+/// Deep Link로 진입 시 자료 로드 후 MaterialDetailScreen 표시
+/// ===============================
+class _MaterialDetailLoader extends StatefulWidget {
+  final String sessionId;
+  final String materialId;
+
+  const _MaterialDetailLoader({
+    required this.sessionId,
+    required this.materialId,
+  });
+
+  @override
+  State<_MaterialDetailLoader> createState() => _MaterialDetailLoaderState();
+}
+
+class _MaterialDetailLoaderState extends State<_MaterialDetailLoader> {
+  bool _isLoading = true;
+  MaterialModel? _material;
+  StudentSessionModel? _session;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMaterial();
+  }
+
+  Future<void> _loadMaterial() async {
+    try {
+      final provider = context.read<StudentSessionProvider>();
+
+      // 세션 데이터가 없으면 로드
+      if (provider.sessions.isEmpty) {
+        await provider.loadMySessions();
+      }
+
+      // 세션 찾기
+      _session = provider.getSessionById(widget.sessionId);
+
+      if (_session == null) {
+        setState(() {
+          _errorMessage = '세션을 찾을 수 없습니다';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      // 자료 찾기
+      _material = _session!.materials.firstWhere(
+            (m) => m.id == widget.materialId,
+        orElse: () => throw Exception('자료를 찾을 수 없습니다'),
+      );
+
+      setState(() {
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = '자료를 불러올 수 없습니다: $e';
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('자료 로딩 중...')),
+        body: const Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (_errorMessage != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('오류')),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error_outline, size: 64, color: Colors.red),
+              const SizedBox(height: 16),
+              Text(_errorMessage!),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('돌아가기'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return MaterialDetailScreen(
+      material: _material!,
+      sessionTitle: _session!.title,
+      teacherName: _session!.teacherName,
     );
   }
 }

--- a/pentalk_front/lib/main.dart
+++ b/pentalk_front/lib/main.dart
@@ -14,12 +14,12 @@ import 'models/student_session_model.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  //토큰 저장
-  await AuthService.saveToken(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0ZWFjaGVyX3Rlc3QiLCJyb2xlIjoidGVhY2hlciIsImlhdCI6MTc3MjYwMzk5MCwiZXhwIjoxNzczMjA4NzkwfQ.4_MvcZTSvmfNBeBHqr_jWcWGwH-lfklzhbUVFLMYRAk'
+  // 토큰, 유저ID, Role을 한 번에 저장하도록 수정!
+  await AuthService.saveUserInfo(
+    token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0ZWFjaGVyX3Rlc3QiLCJyb2xlIjoidGVhY2hlciIsImlhdCI6MTc3MjYwMzk5MCwiZXhwIjoxNzczMjA4NzkwfQ.4_MvcZTSvmfNBeBHqr_jWcWGwH-lfklzhbUVFLMYRAk',
+    userId: 'teacher_test',
+    role: 'teacher',
   );
-  await AuthService.saveUserId('teacher_test');
-  await AuthService.saveRole('teacher');
 
   runApp(const MyApp());
 }

--- a/pentalk_front/lib/main.dart
+++ b/pentalk_front/lib/main.dart
@@ -1,273 +1,50 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'dart:async';
-import 'providers/student_session_provider.dart';
 import 'providers/drawing_provider.dart';
 import 'providers/personal_drawing_provider.dart';
-import 'screens/student_home_screen.dart';
-import 'screens/material_detail_screen.dart';
+import 'providers/participants_provider.dart';
 import 'screens/drawing_screen.dart';
-import 'screens/login_screen.dart';  // 👈 추가
-import 'services/deep_link_service.dart';
 import 'services/auth_service.dart';
-import 'utils/route_guard.dart';  // 👈 추가
-import 'models/student_session_model.dart';
 
+/// ===============================
+/// 세션 종료 UI 테스트용 main.dart
+/// ===============================
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await AuthService.clearAll();
+  // 테스트용 토큰 저장
+  await AuthService.saveUserInfo(
+    token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0ZWFjaGVyX3Rlc3QiLCJyb2xlIjoidGVhY2hlciIsImlhdCI6MTc3MjYwMzk5MCwiZXhwIjoxNzczMjA4NzkwfQ.4_MvcZTSvmfNBeBHqr_jWcWGwH-lfklzhbUVFLMYRAk',
+    userId: 'teacher_test',
+    role: 'teacher',
+  );
 
-  // 👇 로그인 상태 확인
-  final isLoggedIn = await RouteGuard.isAuthenticated();
-
-  runApp(MyApp(isLoggedIn: isLoggedIn));
+  runApp(const SessionEndTestApp());
 }
 
-class MyApp extends StatefulWidget {
-  final bool isLoggedIn;  // 👈 추가
-
-  const MyApp({Key? key, required this.isLoggedIn}) : super(key: key);
-
-  @override
-  State<MyApp> createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
-  final DeepLinkService _deepLinkService = DeepLinkService();
-  final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
-  StreamSubscription<Uri>? _linkSubscription;
-
-  @override
-  void initState() {
-    super.initState();
-    _initDeepLinks();
-  }
-
-  /// Deep Link 초기화
-  void _initDeepLinks() {
-    // 1. 앱 시작 시 초기 링크 확인
-    _handleInitialLink();
-
-    // 2. 백그라운드에서 복귀 시 링크 감지
-    _linkSubscription = _deepLinkService.uriLinkStream.listen(
-          (Uri uri) {
-        debugPrint('📱 Received Deep Link: $uri');
-        _handleDeepLink(uri.toString());
-      },
-      onError: (err) {
-        debugPrint('❌ Deep Link error: $err');
-      },
-    );
-  }
-
-  /// 앱 시작 시 초기 링크 처리
-  Future<void> _handleInitialLink() async {
-    try {
-      final initialLink = await _deepLinkService.getInitialLink();
-      if (initialLink != null) {
-        // 앱이 완전히 로드된 후 처리
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          _handleDeepLink(initialLink);
-        });
-      }
-    } catch (e) {
-      debugPrint('❌ Failed to handle initial link: $e');
-    }
-  }
-
-  /// Deep Link 처리
-  void _handleDeepLink(String uriString) {
-    final params = _deepLinkService.parseMaterialLink(uriString);
-
-    if (params == null) {
-      debugPrint('⚠️ Invalid Deep Link format');
-      return;
-    }
-
-    final sessionId = params['sessionId']!;
-    final materialId = params['materialId']!;
-
-    // Navigator로 화면 이동
-    _navigatorKey.currentState?.pushNamed(
-      '/material',
-      arguments: {
-        'sessionId': sessionId,
-        'materialId': materialId,
-      },
-    );
-  }
-
-  @override
-  void dispose() {
-    _linkSubscription?.cancel();
-    super.dispose();
-  }
+class SessionEndTestApp extends StatelessWidget {
+  const SessionEndTestApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (_) => StudentSessionProvider()),
         ChangeNotifierProvider(create: (_) => DrawingProvider()),
         ChangeNotifierProvider(create: (_) => PersonalDrawingProvider()),
+        ChangeNotifierProvider(create: (_) => ParticipantsProvider()),
       ],
       child: MaterialApp(
-        navigatorKey: _navigatorKey,
-        title: '하이브리드 교실 - 학생',
+        title: '세션 종료 UI 테스트',
         debugShowCheckedModeBanner: false,
         theme: ThemeData(
           primarySwatch: Colors.blue,
           useMaterial3: true,
-          colorScheme: ColorScheme.fromSeed(
-            seedColor: Colors.blue,
-            brightness: Brightness.light,
-          ),
-          appBarTheme: const AppBarTheme(
-            centerTitle: false,
-            elevation: 0,
-          ),
         ),
-        // 👇 초기 화면: 로그인 여부에 따라
-        home: widget.isLoggedIn
-            ? const StudentHomeScreen()
-            : const LoginScreen(),
-
-        // Named Routes 정의
-        routes: {
-          '/login': (context) => const LoginScreen(),  // 👈 추가
-          '/home': (context) => const StudentHomeScreen(),
-        },
-
-        // Dynamic Routes (Deep Link용)
-        onGenerateRoute: (settings) {
-          // /material 라우트 처리
-          if (settings.name == '/material') {
-            final args = settings.arguments as Map<String, String>?;
-
-            if (args == null) {
-              return null;
-            }
-
-            final sessionId = args['sessionId']!;
-            final materialId = args['materialId']!;
-
-            return MaterialPageRoute(
-              builder: (context) => _MaterialDetailLoader(
-                sessionId: sessionId,
-                materialId: materialId,
-              ),
-            );
-          }
-
-          return null;
-        },
+        home: const DrawingScreen(
+          materialTitle: '🧪 세션 종료 UI 테스트',
+          isTeacher: true,
+        ),
       ),
-    );
-  }
-}
-
-/// ===============================
-/// Deep Link로 진입 시 자료 로드 후 MaterialDetailScreen 표시
-/// ===============================
-class _MaterialDetailLoader extends StatefulWidget {
-  final String sessionId;
-  final String materialId;
-
-  const _MaterialDetailLoader({
-    required this.sessionId,
-    required this.materialId,
-  });
-
-  @override
-  State<_MaterialDetailLoader> createState() => _MaterialDetailLoaderState();
-}
-
-class _MaterialDetailLoaderState extends State<_MaterialDetailLoader> {
-  bool _isLoading = true;
-  MaterialModel? _material;
-  StudentSessionModel? _session;
-  String? _errorMessage;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadMaterial();
-  }
-
-  Future<void> _loadMaterial() async {
-    try {
-      final provider = context.read<StudentSessionProvider>();
-
-      // 세션 데이터가 없으면 로드
-      if (provider.sessions.isEmpty) {
-        await provider.loadMySessions();
-      }
-
-      // 세션 찾기
-      _session = provider.getSessionById(widget.sessionId);
-
-      if (_session == null) {
-        setState(() {
-          _errorMessage = '세션을 찾을 수 없습니다';
-          _isLoading = false;
-        });
-        return;
-      }
-
-      // 자료 찾기
-      _material = _session!.materials.firstWhere(
-            (m) => m.id == widget.materialId,
-        orElse: () => throw Exception('자료를 찾을 수 없습니다'),
-      );
-
-      setState(() {
-        _isLoading = false;
-      });
-    } catch (e) {
-      setState(() {
-        _errorMessage = '자료를 불러올 수 없습니다: $e';
-        _isLoading = false;
-      });
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (_isLoading) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('자료 로딩 중...')),
-        body: const Center(
-          child: CircularProgressIndicator(),
-        ),
-      );
-    }
-
-    if (_errorMessage != null) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('오류')),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(Icons.error_outline, size: 64, color: Colors.red),
-              const SizedBox(height: 16),
-              Text(_errorMessage!),
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: () => Navigator.pop(context),
-                child: const Text('돌아가기'),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
-    return MaterialDetailScreen(
-      material: _material!,
-      sessionTitle: _session!.title,
-      teacherName: _session!.teacherName,
     );
   }
 }

--- a/pentalk_front/lib/main.dart
+++ b/pentalk_front/lib/main.dart
@@ -7,25 +7,27 @@ import 'providers/personal_drawing_provider.dart';
 import 'screens/student_home_screen.dart';
 import 'screens/material_detail_screen.dart';
 import 'screens/drawing_screen.dart';
+import 'screens/login_screen.dart';  // 👈 추가
 import 'services/deep_link_service.dart';
 import 'services/auth_service.dart';
+import 'utils/route_guard.dart';  // 👈 추가
 import 'models/student_session_model.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // 토큰, 유저ID, Role을 한 번에 저장하도록 수정!
-  await AuthService.saveUserInfo(
-    token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0ZWFjaGVyX3Rlc3QiLCJyb2xlIjoidGVhY2hlciIsImlhdCI6MTc3MjYwMzk5MCwiZXhwIjoxNzczMjA4NzkwfQ.4_MvcZTSvmfNBeBHqr_jWcWGwH-lfklzhbUVFLMYRAk',
-    userId: 'teacher_test',
-    role: 'teacher',
-  );
+  await AuthService.clearAll();
 
-  runApp(const MyApp());
+  // 👇 로그인 상태 확인
+  final isLoggedIn = await RouteGuard.isAuthenticated();
+
+  runApp(MyApp(isLoggedIn: isLoggedIn));
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  final bool isLoggedIn;  // 👈 추가
+
+  const MyApp({Key? key, required this.isLoggedIn}) : super(key: key);
 
   @override
   State<MyApp> createState() => _MyAppState();
@@ -126,10 +128,14 @@ class _MyAppState extends State<MyApp> {
             elevation: 0,
           ),
         ),
-        home: const StudentHomeScreen(),
+        // 👇 초기 화면: 로그인 여부에 따라
+        home: widget.isLoggedIn
+            ? const StudentHomeScreen()
+            : const LoginScreen(),
 
         // Named Routes 정의
         routes: {
+          '/login': (context) => const LoginScreen(),  // 👈 추가
           '/home': (context) => const StudentHomeScreen(),
         },
 

--- a/pentalk_front/lib/main.dart
+++ b/pentalk_front/lib/main.dart
@@ -8,9 +8,19 @@ import 'screens/student_home_screen.dart';
 import 'screens/material_detail_screen.dart';
 import 'screens/drawing_screen.dart';
 import 'services/deep_link_service.dart';
+import 'services/auth_service.dart';
 import 'models/student_session_model.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  //토큰 저장
+  await AuthService.saveToken(
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ0ZWFjaGVyX3Rlc3QiLCJyb2xlIjoidGVhY2hlciIsImlhdCI6MTc3MjYwMzk5MCwiZXhwIjoxNzczMjA4NzkwfQ.4_MvcZTSvmfNBeBHqr_jWcWGwH-lfklzhbUVFLMYRAk'
+  );
+  await AuthService.saveUserId('teacher_test');
+  await AuthService.saveRole('teacher');
+
   runApp(const MyApp());
 }
 

--- a/pentalk_front/lib/models/drawing_models.dart
+++ b/pentalk_front/lib/models/drawing_models.dart
@@ -95,6 +95,31 @@ class Stroke {
     this.refinedPoints,
   });
 
+  //JSON → Stroke
+  factory Stroke.fromJson(Map<String, dynamic> json) {
+    // 1. 점(points) 데이터 파싱
+    final ptsList = json['pts'] as List<dynamic>? ?? [];
+    final parsedPoints = ptsList
+        .map((pt) => DrawPoint.fromJson(pt as Map<String, dynamic>))
+        .toList();
+
+    // 2. 색상(color) 파싱 (안전 처리 포함)
+    Color parsedColor = Colors.black;
+    if (json['c'] != null) {
+      final hex = (json['c'] as String).replaceAll('#', '');
+      if (hex.length == 6) {
+        parsedColor = Color(int.parse('FF$hex', radix: 16));
+      }
+    }
+
+    return Stroke(
+      strokeId: json['sId'] as int,
+      color: parsedColor,
+      width: json['w'] != null ? (json['w'] as num).toDouble() : 2.5,
+      points: parsedPoints,
+    );
+  }
+
   Stroke copyWith({
     int? strokeId,
     Color? color,

--- a/pentalk_front/lib/models/participant_model.dart
+++ b/pentalk_front/lib/models/participant_model.dart
@@ -1,0 +1,40 @@
+/// ===============================
+/// Participant 모델
+/// ===============================
+class Participant {
+  final String userId;
+  final String role;
+
+  Participant({
+    required this.userId,
+    required this.role,
+  });
+
+  bool get isTeacher => role == 'teacher';
+  bool get isStudent => role == 'student';
+
+  factory Participant.fromJson(Map<String, dynamic> json) {
+    return Participant(
+      userId: json['userId'] as String,
+      role: json['role'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'userId': userId,
+      'role': role,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Participant &&
+        other.userId == userId &&
+        other.role == role;
+  }
+
+  @override
+  int get hashCode => userId.hashCode ^ role.hashCode;
+}

--- a/pentalk_front/lib/models/personal_stroke.dart
+++ b/pentalk_front/lib/models/personal_stroke.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'drawing_models.dart';
+
+/// ===============================
+/// 개인 필기용 Stroke 모델 (로컬 DB 저장)
+/// ===============================
+class PersonalStroke {
+  final int? id; // SQLite auto-increment ID
+  final String pageId; // materialTitle
+  final int strokeId; // 고유 stroke ID
+  final Color color;
+  final double width;
+  final List<DrawPoint> points;
+  final List<DrawPoint>? refinedPoints;
+  final DateTime timestamp; // 생성 시간
+
+  PersonalStroke({
+    this.id,
+    required this.pageId,
+    required this.strokeId,
+    required this.color,
+    required this.width,
+    required this.points,
+    this.refinedPoints,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  /// Stroke → PersonalStroke 변환
+  factory PersonalStroke.fromStroke(
+      Stroke stroke,
+      String pageId, {
+        DateTime? timestamp,
+      }) {
+    return PersonalStroke(
+      pageId: pageId,
+      strokeId: stroke.strokeId,
+      color: stroke.color,
+      width: stroke.width,
+      points: stroke.points,
+      refinedPoints: stroke.refinedPoints,
+      timestamp: timestamp,
+    );
+  }
+
+  /// PersonalStroke → Stroke 변환
+  Stroke toStroke() {
+    return Stroke(
+      strokeId: strokeId,
+      color: color,
+      width: width,
+      points: points,
+      refinedPoints: refinedPoints,
+    );
+  }
+
+  /// JSON → PersonalStroke (SQLite 저장용)
+  factory PersonalStroke.fromJson(Map<String, dynamic> json) {
+    return PersonalStroke(
+      id: json['id'] as int?,
+      pageId: json['pageId'] as String,
+      strokeId: json['strokeId'] as int,
+      color: Color(json['color'] as int),
+      width: (json['width'] as num).toDouble(),
+      points: (json['points'] as List<dynamic>)
+          .map((p) => DrawPoint.fromJson(p as Map<String, dynamic>))
+          .toList(),
+      refinedPoints: json['refinedPoints'] != null
+          ? (json['refinedPoints'] as List<dynamic>)
+          .map((p) => DrawPoint.fromJson(p as Map<String, dynamic>))
+          .toList()
+          : null,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+    );
+  }
+
+  /// PersonalStroke → JSON (SQLite 저장용)
+  Map<String, dynamic> toJson() {
+    return {
+      if (id != null) 'id': id,
+      'pageId': pageId,
+      'strokeId': strokeId,
+      'color': color.value,
+      'width': width,
+      'points': points.map((p) => p.toJson()).toList(),
+      if (refinedPoints != null)
+        'refinedPoints': refinedPoints!.map((p) => p.toJson()).toList(),
+      'timestamp': timestamp.toIso8601String(),
+    };
+  }
+
+  /// SQLite Row → PersonalStroke
+  factory PersonalStroke.fromMap(Map<String, dynamic> map) {
+    // SQLite에서는 points를 JSON 문자열로 저장했다가 파싱
+    final pointsData = map['points_json'] as String;
+    final refinedPointsData = map['refined_points_json'] as String?;
+
+    return PersonalStroke(
+      id: map['id'] as int,
+      pageId: map['page_id'] as String,
+      strokeId: map['stroke_id'] as int,
+      color: Color(map['color'] as int),
+      width: (map['width'] as num).toDouble(),
+      points: _parsePoints(pointsData),
+      refinedPoints: refinedPointsData != null ? _parsePoints(refinedPointsData) : null,
+      timestamp: DateTime.parse(map['timestamp'] as String),
+    );
+  }
+
+  /// PersonalStroke → SQLite Row
+  Map<String, dynamic> toMap() {
+    return {
+      if (id != null) 'id': id,
+      'page_id': pageId,
+      'stroke_id': strokeId,
+      'color': color.value,
+      'width': width,
+      'points_json': _pointsToJson(points),
+      'refined_points_json': refinedPoints != null ? _pointsToJson(refinedPoints!) : null,
+      'timestamp': timestamp.toIso8601String(),
+    };
+  }
+
+  /// DrawPoint 리스트 → JSON 문자열
+  static String _pointsToJson(List<DrawPoint> points) {
+    return '[${points.map((p) => '{"x":${p.x},"y":${p.y}${p.pressure != null ? ',"p":${p.pressure}' : ''}}').join(',')}]';
+  }
+
+  /// JSON 문자열 → DrawPoint 리스트
+  static List<DrawPoint> _parsePoints(String json) {
+    // 간단한 JSON 파싱 (dart:convert 사용하지 않고)
+    final cleaned = json.replaceAll('[', '').replaceAll(']', '');
+    if (cleaned.isEmpty) return [];
+
+    final List<DrawPoint> points = [];
+    final regex = RegExp(r'\{([^}]+)\}');
+    final matches = regex.allMatches(cleaned);
+
+    for (final match in matches) {
+      final content = match.group(1)!;
+      final parts = content.split(',');
+
+      double? x, y, p;
+      for (final part in parts) {
+        final kv = part.split(':');
+        final key = kv[0].replaceAll('"', '').trim();
+        final value = double.tryParse(kv[1].trim());
+
+        if (key == 'x') x = value;
+        if (key == 'y') y = value;
+        if (key == 'p') p = value;
+      }
+
+      if (x != null && y != null) {
+        points.add(DrawPoint(x: x, y: y, pressure: p));
+      }
+    }
+
+    return points;
+  }
+
+  PersonalStroke copyWith({
+    int? id,
+    String? pageId,
+    int? strokeId,
+    Color? color,
+    double? width,
+    List<DrawPoint>? points,
+    List<DrawPoint>? refinedPoints,
+    DateTime? timestamp,
+  }) {
+    return PersonalStroke(
+      id: id ?? this.id,
+      pageId: pageId ?? this.pageId,
+      strokeId: strokeId ?? this.strokeId,
+      color: color ?? this.color,
+      width: width ?? this.width,
+      points: points ?? this.points,
+      refinedPoints: refinedPoints ?? this.refinedPoints,
+      timestamp: timestamp ?? this.timestamp,
+    );
+  }
+}

--- a/pentalk_front/lib/providers/batch_upload_provider.dart
+++ b/pentalk_front/lib/providers/batch_upload_provider.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/foundation.dart';
+import 'dart:async';
+import '../models/drawing_models.dart';
+import '../services/api_service.dart';
+import '../services/upload_queue_service.dart';
+
+/// ===============================
+/// 배치 업로드 Provider
+/// 판서 데이터를 모아서 서버로 전송
+/// ===============================
+class BatchUploadProvider extends ChangeNotifier {
+  // 배치 조건
+  static const int batchSize = 50; // 50개 모이면 전송
+  static const Duration batchInterval = Duration(seconds: 30); // 30초마다 전송
+  static const int maxRetries = 3; // 최대 재시도 횟수
+
+  // 현재 배치 (메모리)
+  final List<Stroke> _pendingStrokes = [];
+  Timer? _batchTimer;
+  bool _isUploading = false;
+
+  String? _sessionId;
+
+  // 통계
+  int _totalUploaded = 0;
+  int _totalFailed = 0;
+
+  int get pendingCount => _pendingStrokes.length;
+  int get totalUploaded => _totalUploaded;
+  int get totalFailed => _totalFailed;
+  bool get isUploading => _isUploading;
+
+  /// ===============================
+  /// 세션 시작 (타이머 시작)
+  /// ===============================
+  void startSession(String sessionId) {
+    _sessionId = sessionId;
+    _startBatchTimer();
+    _retryFailedBatches(); // 이전 실패한 것들 재시도
+    debugPrint('🚀 Batch upload session started: $sessionId');
+  }
+
+  /// ===============================
+  /// 세션 종료 (남은 거 전부 전송)
+  /// ===============================
+  Future<void> endSession() async {
+    _stopBatchTimer();
+
+    if (_pendingStrokes.isNotEmpty) {
+      debugPrint('📤 Sending remaining ${_pendingStrokes.length} strokes...');
+      await _sendBatch();
+    }
+
+    _sessionId = null;
+    debugPrint('🛑 Batch upload session ended');
+  }
+
+  /// ===============================
+  /// 선 추가 (교사 판서만!)
+  /// ===============================
+  void addStroke(Stroke stroke) {
+    _pendingStrokes.add(stroke);
+    debugPrint('➕ Added stroke (${_pendingStrokes.length}/$batchSize)');
+
+    // 50개 모이면 즉시 전송
+    if (_pendingStrokes.length >= batchSize) {
+      debugPrint('📦 Batch size reached, sending...');
+      _sendBatch();
+    }
+
+    notifyListeners();
+  }
+
+  /// ===============================
+  /// 배치 타이머 시작
+  /// ===============================
+  void _startBatchTimer() {
+    _batchTimer?.cancel();
+    _batchTimer = Timer.periodic(batchInterval, (timer) {
+      if (_pendingStrokes.isNotEmpty) {
+        debugPrint('⏰ Timer triggered, sending ${_pendingStrokes.length} strokes...');
+        _sendBatch();
+      }
+    });
+  }
+
+  /// ===============================
+  /// 배치 타이머 중지
+  /// ===============================
+  void _stopBatchTimer() {
+    _batchTimer?.cancel();
+    _batchTimer = null;
+  }
+
+  /// ===============================
+  /// 배치 전송
+  /// ===============================
+  Future<void> _sendBatch() async {
+    if (_isUploading || _pendingStrokes.isEmpty || _sessionId == null) {
+      return;
+    }
+
+    _isUploading = true;
+    notifyListeners();
+
+    // 전송할 데이터 복사
+    final strokesToSend = List<Stroke>.from(_pendingStrokes);
+    _pendingStrokes.clear();
+
+    try {
+      // API 호출
+      final response = await ApiService.saveStrokes(
+        sessionId: _sessionId!,
+        strokes: strokesToSend,
+      );
+
+      if (response.success) {
+        // 성공
+        _totalUploaded += strokesToSend.length;
+        debugPrint('✅ Uploaded ${strokesToSend.length} strokes');
+      } else {
+        // 실패 → Queue에 저장
+        debugPrint('❌ Upload failed: ${response.message}');
+        await _saveToQueue(strokesToSend);
+        _totalFailed += strokesToSend.length;
+      }
+    } catch (e) {
+      // 네트워크 에러 → Queue에 저장
+      debugPrint('❌ Network error: $e');
+      await _saveToQueue(strokesToSend);
+      _totalFailed += strokesToSend.length;
+    } finally {
+      _isUploading = false;
+      notifyListeners();
+    }
+  }
+
+  /// ===============================
+  /// Queue에 저장 (실패 시)
+  /// ===============================
+  Future<void> _saveToQueue(List<Stroke> strokes) async {
+    if (_sessionId == null) return;
+
+    await UploadQueueService.addToQueue(
+      sessionId: _sessionId!,
+      strokes: strokes,
+    );
+
+    debugPrint('💾 Saved to queue for retry');
+  }
+
+  /// ===============================
+  /// Queue에서 재시도
+  /// ===============================
+  Future<void> _retryFailedBatches() async {
+    try {
+      final batches = await UploadQueueService.getPendingBatches();
+
+      if (batches.isEmpty) {
+        debugPrint('✅ No failed batches to retry');
+        return;
+      }
+
+      debugPrint('🔄 Retrying ${batches.length} failed batches...');
+
+      for (final batch in batches) {
+        // 재시도 횟수 체크
+        if (batch.retryCount >= maxRetries) {
+          debugPrint('⚠️ Max retries exceeded for batch ${batch.id}, removing...');
+          await UploadQueueService.removeFromQueue(batch.id);
+          continue;
+        }
+
+        // 재시도
+        try {
+          final response = await ApiService.saveStrokes(
+            sessionId: batch.sessionId,
+            strokes: batch.strokes,
+          );
+
+          if (response.success) {
+            // 성공 → Queue에서 삭제
+            await UploadQueueService.removeFromQueue(batch.id);
+            _totalUploaded += batch.strokes.length;
+            debugPrint('✅ Retry successful for batch ${batch.id}');
+          } else {
+            // 실패 → 재시도 횟수 증가
+            await UploadQueueService.incrementRetryCount(batch.id);
+            debugPrint('❌ Retry failed for batch ${batch.id}: ${response.message}');
+          }
+        } catch (e) {
+          // 네트워크 에러 → 재시도 횟수 증가
+          await UploadQueueService.incrementRetryCount(batch.id);
+          debugPrint('❌ Retry error for batch ${batch.id}: $e');
+        }
+
+        // 과부하 방지
+        await Future.delayed(const Duration(milliseconds: 500));
+      }
+    } catch (e) {
+      debugPrint('❌ Failed to retry batches: $e');
+    }
+  }
+
+  /// ===============================
+  /// Queue 통계 가져오기
+  /// ===============================
+  Future<QueueStats> getQueueStats() async {
+    return await UploadQueueService.getStats();
+  }
+
+  /// ===============================
+  /// 수동 재시도
+  /// ===============================
+  Future<void> retryNow() async {
+    debugPrint('🔄 Manual retry triggered');
+    await _retryFailedBatches();
+  }
+
+  /// ===============================
+  /// 통계 초기화
+  /// ===============================
+  void resetStats() {
+    _totalUploaded = 0;
+    _totalFailed = 0;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _stopBatchTimer();
+    super.dispose();
+  }
+}

--- a/pentalk_front/lib/providers/drawing_provider.dart
+++ b/pentalk_front/lib/providers/drawing_provider.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../models/drawing_models.dart';
@@ -79,6 +78,7 @@ class DrawingProvider extends ChangeNotifier {
     required String userId,
     required String roomId,
     required bool isTeacher,
+    String? jwtToken, // JWT 토큰 추가
   }) async {
     _userId = userId;
     _roomId = roomId;
@@ -90,6 +90,7 @@ class DrawingProvider extends ChangeNotifier {
         userId: userId,
         roomId: roomId,
         isTeacher: isTeacher,
+        jwtToken: jwtToken, // JWT 전달
       );
 
       _isSocketConnected = true;

--- a/pentalk_front/lib/providers/drawing_provider.dart
+++ b/pentalk_front/lib/providers/drawing_provider.dart
@@ -3,8 +3,10 @@ import 'package:flutter/services.dart';
 import '../models/drawing_models.dart';
 import '../services/socket_service.dart';
 
+/// ===============================
 /// 판서 데이터 Provider (Socket.IO 통합)
 /// 최적화: notifyListeners() 호출 최소화
+/// ===============================
 class DrawingProvider extends ChangeNotifier {
   static const platform = MethodChannel('pentalk/drawing');
 
@@ -37,25 +39,15 @@ class DrawingProvider extends ChangeNotifier {
 
   // Getters
   Map<int, Stroke> get myStrokes => _myStrokes;
-
   Map<int, Stroke> get myActiveStrokes => _myActiveStrokes;
-
   Map<int, Stroke> get othersStrokes => _othersStrokes;
-
   Map<int, Stroke> get othersActiveStrokes => _othersActiveStrokes;
-
   String? get backgroundUrl => _backgroundUrl;
-
   bool get isDrawingMode => _isDrawingMode;
-
   Color get currentColor => _currentColor;
-
   double get currentWidth => _currentWidth;
-
   bool get isSocketConnected => _isSocketConnected;
-
   String? get userId => _userId;
-
   String? get roomId => _roomId;
 
   /// 내 모든 선들 (완성 + 진행중)
@@ -78,7 +70,9 @@ class DrawingProvider extends ChangeNotifier {
     _setupSocketListeners();
   }
 
+  /// ===============================
   /// Socket.IO 연결
+  /// ===============================
   Future<void> connectSocket({
     required String serverUrl,
     required String userId,
@@ -108,15 +102,13 @@ class DrawingProvider extends ChangeNotifier {
     }
   }
 
+  /// ===============================
   /// Socket.IO 이벤트 리스너 설정
+  /// ===============================
   void _setupSocketListeners() {
     // 판서 이벤트 수신
     _socketService.onDrawEventReceived = (event) {
       _handleReceivedDrawEvent(event);
-    };
-    //중간 입장 시 전체 그림 받아오기
-    _socketService.onSyncState = (strokesList) {
-      _handleSyncState(strokesList);
     };
 
     // 연결 상태
@@ -140,9 +132,16 @@ class DrawingProvider extends ChangeNotifier {
     _socketService.onUserLeft = (userId) {
       debugPrint('👋 User left: $userId');
     };
+
+    // 세션 종료 알림
+    _socketService.onSessionEnded = (data) {
+      _handleSessionEnded(data);
+    };
   }
 
+  /// ===============================
   /// MethodChannel 설정
+  /// ===============================
   void _setupMethodChannel() {
     platform.setMethodCallHandler((call) async {
       try {
@@ -157,6 +156,7 @@ class DrawingProvider extends ChangeNotifier {
     });
   }
 
+  /// ===============================
   /// 수신된 판서 이벤트 처리 (다른 사람의 펜)
   /// ===============================
   void _handleReceivedDrawEvent(DrawEvent event) {
@@ -194,7 +194,7 @@ class DrawingProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  //다른 사람의 draw_move
+  /// 다른 사람의 draw_move
   void _handleOthersDrawMove(DrawEvent event) {
     if (event.point == null) return;
 
@@ -205,8 +205,7 @@ class DrawingProvider extends ChangeNotifier {
     }
 
     final updatedPoints = [...stroke.points, event.point!];
-    _othersActiveStrokes[event.strokeId] =
-        stroke.copyWith(points: updatedPoints);
+    _othersActiveStrokes[event.strokeId] = stroke.copyWith(points: updatedPoints);
 
     if (updatedPoints.length % 3 == 0) {
       notifyListeners();
@@ -249,7 +248,9 @@ class DrawingProvider extends ChangeNotifier {
     }
   }
 
-  // 내 판서 이벤트 처리 (로컬)
+  /// ===============================
+  /// 내 판서 이벤트 처리 (로컬)
+  /// ===============================
   void _handleMyDrawStart(DrawEvent event) {
     if (event.point == null) return;
 
@@ -288,6 +289,8 @@ class DrawingProvider extends ChangeNotifier {
 
     _myStrokes[event.strokeId] = finalStroke;
     notifyListeners();
+
+
   }
 
   void _handleMyUndo(DrawEvent event) {
@@ -299,7 +302,9 @@ class DrawingProvider extends ChangeNotifier {
     }
   }
 
+  /// ===============================
   /// 설정 관련
+  /// ===============================
   void setBackgroundUrl(String? url) {
     if (_backgroundUrl != url) {
       _backgroundUrl = url;
@@ -326,11 +331,11 @@ class DrawingProvider extends ChangeNotifier {
     }
   }
 
+  /// ===============================
   /// 내가 그릴 때: 로컬 + 소켓 전송
+  /// ===============================
   int sendDrawStart(DrawPoint point) {
-    final strokeId = DateTime
-        .now()
-        .millisecondsSinceEpoch;
+    final strokeId = DateTime.now().millisecondsSinceEpoch;
 
     final event = DrawEvent(
       eventType: DrawEventType.drawStart,
@@ -447,31 +452,23 @@ class DrawingProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// ===============================
+  /// ===============================
+  /// 세션 종료 처리 (session:ended 이벤트 수신)
+  /// ===============================
+  void _handleSessionEnded(Map<String, dynamic> data) {
+    debugPrint('📥 Session ended: $data');
+
+    // sessionEnded 콜백 호출 (UI에서 처리)
+    onSessionEnded?.call(data);
+  }
+
+  // 세션 종료 콜백 (DrawingScreen에서 설정)
+  Function(Map<String, dynamic>)? onSessionEnded;
+
   @override
   void dispose() {
     disconnectSocket();
     super.dispose();
-  }
-  /// 중간 입장 시 이전 판서 데이터 복구
-  void _handleSyncState(List<dynamic> strokesList) {
-    _othersStrokes.clear(); // 기존 판서 초기화
-
-    for (var item in strokesList) {
-      try {
-        final Map<String, dynamic> dataMap = Map<String, dynamic>.from(item);
-
-        // 새로 만든 Stroke.fromJson을 깔끔하게 사용!
-        final stroke = Stroke.fromJson(dataMap);
-
-        if (stroke.points.isNotEmpty) {
-          _othersStrokes[stroke.strokeId] = stroke;
-        }
-      } catch (e) {
-        debugPrint('Error parsing sync stroke: $e');
-      }
-    }
-
-    notifyListeners(); // 화면 새로고침
-    debugPrint('✅ Sync complete: ${_othersStrokes.length} strokes loaded');
   }
 }

--- a/pentalk_front/lib/providers/drawing_provider.dart
+++ b/pentalk_front/lib/providers/drawing_provider.dart
@@ -13,6 +13,9 @@ class DrawingProvider extends ChangeNotifier {
   // Socket.IO 서비스
   final SocketService _socketService = SocketService();
 
+  // ✅ SocketService getter 추가 (DrawingScreen에서 접근용)
+  SocketService get socketService => _socketService;
+
   // 내 펜 (로컬에서 그린 선들)
   final Map<int, Stroke> _myStrokes = {};
   final Map<int, Stroke> _myActiveStrokes = {};
@@ -95,6 +98,10 @@ class DrawingProvider extends ChangeNotifier {
 
       _isSocketConnected = true;
       notifyListeners();
+
+      // ✅ Presence 리스너 설정 추가!
+      _setupPresenceListeners();
+
     } catch (e) {
       debugPrint('Failed to connect socket: $e');
       _isSocketConnected = false;
@@ -137,6 +144,17 @@ class DrawingProvider extends ChangeNotifier {
     _socketService.onSessionEnded = (data) {
       _handleSessionEnded(data);
     };
+  }
+
+  /// ===============================
+  /// ✅ Presence 리스너 설정 (신규 추가!)
+  /// ===============================
+  void _setupPresenceListeners() {
+    // SocketService에 Presence 리스너 설정
+    // 실제 콜백 연결은 DrawingScreen에서 수행
+    _socketService.setupPresenceListeners();
+
+    debugPrint('🔔 Presence listeners setup completed');
   }
 
   /// ===============================
@@ -289,8 +307,6 @@ class DrawingProvider extends ChangeNotifier {
 
     _myStrokes[event.strokeId] = finalStroke;
     notifyListeners();
-
-
   }
 
   void _handleMyUndo(DrawEvent event) {
@@ -452,7 +468,6 @@ class DrawingProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// ===============================
   /// ===============================
   /// 세션 종료 처리 (session:ended 이벤트 수신)
   /// ===============================

--- a/pentalk_front/lib/providers/drawing_provider.dart
+++ b/pentalk_front/lib/providers/drawing_provider.dart
@@ -3,10 +3,8 @@ import 'package:flutter/services.dart';
 import '../models/drawing_models.dart';
 import '../services/socket_service.dart';
 
-/// ===============================
 /// 판서 데이터 Provider (Socket.IO 통합)
 /// 최적화: notifyListeners() 호출 최소화
-/// ===============================
 class DrawingProvider extends ChangeNotifier {
   static const platform = MethodChannel('pentalk/drawing');
 
@@ -39,15 +37,25 @@ class DrawingProvider extends ChangeNotifier {
 
   // Getters
   Map<int, Stroke> get myStrokes => _myStrokes;
+
   Map<int, Stroke> get myActiveStrokes => _myActiveStrokes;
+
   Map<int, Stroke> get othersStrokes => _othersStrokes;
+
   Map<int, Stroke> get othersActiveStrokes => _othersActiveStrokes;
+
   String? get backgroundUrl => _backgroundUrl;
+
   bool get isDrawingMode => _isDrawingMode;
+
   Color get currentColor => _currentColor;
+
   double get currentWidth => _currentWidth;
+
   bool get isSocketConnected => _isSocketConnected;
+
   String? get userId => _userId;
+
   String? get roomId => _roomId;
 
   /// 내 모든 선들 (완성 + 진행중)
@@ -70,9 +78,7 @@ class DrawingProvider extends ChangeNotifier {
     _setupSocketListeners();
   }
 
-  /// ===============================
   /// Socket.IO 연결
-  /// ===============================
   Future<void> connectSocket({
     required String serverUrl,
     required String userId,
@@ -102,13 +108,15 @@ class DrawingProvider extends ChangeNotifier {
     }
   }
 
-  /// ===============================
   /// Socket.IO 이벤트 리스너 설정
-  /// ===============================
   void _setupSocketListeners() {
     // 판서 이벤트 수신
     _socketService.onDrawEventReceived = (event) {
       _handleReceivedDrawEvent(event);
+    };
+    //중간 입장 시 전체 그림 받아오기
+    _socketService.onSyncState = (strokesList) {
+      _handleSyncState(strokesList);
     };
 
     // 연결 상태
@@ -134,9 +142,7 @@ class DrawingProvider extends ChangeNotifier {
     };
   }
 
-  /// ===============================
   /// MethodChannel 설정
-  /// ===============================
   void _setupMethodChannel() {
     platform.setMethodCallHandler((call) async {
       try {
@@ -151,7 +157,6 @@ class DrawingProvider extends ChangeNotifier {
     });
   }
 
-  /// ===============================
   /// 수신된 판서 이벤트 처리 (다른 사람의 펜)
   /// ===============================
   void _handleReceivedDrawEvent(DrawEvent event) {
@@ -189,7 +194,7 @@ class DrawingProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// 다른 사람의 draw_move
+  //다른 사람의 draw_move
   void _handleOthersDrawMove(DrawEvent event) {
     if (event.point == null) return;
 
@@ -200,7 +205,8 @@ class DrawingProvider extends ChangeNotifier {
     }
 
     final updatedPoints = [...stroke.points, event.point!];
-    _othersActiveStrokes[event.strokeId] = stroke.copyWith(points: updatedPoints);
+    _othersActiveStrokes[event.strokeId] =
+        stroke.copyWith(points: updatedPoints);
 
     if (updatedPoints.length % 3 == 0) {
       notifyListeners();
@@ -243,9 +249,7 @@ class DrawingProvider extends ChangeNotifier {
     }
   }
 
-  /// ===============================
-  /// 내 판서 이벤트 처리 (로컬)
-  /// ===============================
+  // 내 판서 이벤트 처리 (로컬)
   void _handleMyDrawStart(DrawEvent event) {
     if (event.point == null) return;
 
@@ -295,9 +299,7 @@ class DrawingProvider extends ChangeNotifier {
     }
   }
 
-  /// ===============================
   /// 설정 관련
-  /// ===============================
   void setBackgroundUrl(String? url) {
     if (_backgroundUrl != url) {
       _backgroundUrl = url;
@@ -324,11 +326,11 @@ class DrawingProvider extends ChangeNotifier {
     }
   }
 
-  /// ===============================
   /// 내가 그릴 때: 로컬 + 소켓 전송
-  /// ===============================
   int sendDrawStart(DrawPoint point) {
-    final strokeId = DateTime.now().millisecondsSinceEpoch;
+    final strokeId = DateTime
+        .now()
+        .millisecondsSinceEpoch;
 
     final event = DrawEvent(
       eventType: DrawEventType.drawStart,
@@ -449,5 +451,27 @@ class DrawingProvider extends ChangeNotifier {
   void dispose() {
     disconnectSocket();
     super.dispose();
+  }
+  /// 중간 입장 시 이전 판서 데이터 복구
+  void _handleSyncState(List<dynamic> strokesList) {
+    _othersStrokes.clear(); // 기존 판서 초기화
+
+    for (var item in strokesList) {
+      try {
+        final Map<String, dynamic> dataMap = Map<String, dynamic>.from(item);
+
+        // 새로 만든 Stroke.fromJson을 깔끔하게 사용!
+        final stroke = Stroke.fromJson(dataMap);
+
+        if (stroke.points.isNotEmpty) {
+          _othersStrokes[stroke.strokeId] = stroke;
+        }
+      } catch (e) {
+        debugPrint('Error parsing sync stroke: $e');
+      }
+    }
+
+    notifyListeners(); // 화면 새로고침
+    debugPrint('✅ Sync complete: ${_othersStrokes.length} strokes loaded');
   }
 }

--- a/pentalk_front/lib/providers/drawing_provider.dart
+++ b/pentalk_front/lib/providers/drawing_provider.dart
@@ -461,6 +461,83 @@ class DrawingProvider extends ChangeNotifier {
     }
   }
 
+  /// ===============================
+  /// 저장된 판서 데이터 로드 (읽기 전용 뷰어용)
+  /// ===============================
+  void loadSavedStrokes(List<Map<String, dynamic>> strokesData) {
+    debugPrint('📥 Loading ${strokesData.length} saved strokes');
+
+    _othersStrokes.clear();
+    _othersActiveStrokes.clear();
+
+    for (final strokeData in strokesData) {
+      try {
+        final strokeId = strokeData['sId'] as int;
+
+        // 좌표 파싱
+        final x = (strokeData['x'] as num?)?.toDouble() ?? 0.0;
+        final y = (strokeData['y'] as num?)?.toDouble() ?? 0.0;
+
+        // 점들 파싱
+        final ptsData = strokeData['pts'] as List?;
+        final points = <DrawPoint>[];
+
+        if (ptsData != null) {
+          for (final pt in ptsData) {
+            if (pt is Map) {
+              final ptX = (pt['x'] as num?)?.toDouble() ?? 0.0;
+              final ptY = (pt['y'] as num?)?.toDouble() ?? 0.0;
+              final pressure = (pt['p'] as num?)?.toDouble();
+
+              points.add(DrawPoint(
+                x: ptX,
+                y: ptY,
+                pressure: pressure,
+              ));
+            }
+          }
+        }
+
+        // 시작점도 추가
+        if (points.isEmpty) {
+          points.add(DrawPoint(x: x, y: y));
+        }
+
+        // 색상 파싱 (hex string → Color)
+        Color color = Colors.black;
+        final colorStr = strokeData['c'] as String?;
+        if (colorStr != null && colorStr.startsWith('#')) {
+          try {
+            final hex = colorStr.substring(1);
+            final colorInt = int.parse(hex, radix: 16);
+            color = Color(0xFF000000 | colorInt);
+          } catch (e) {
+            debugPrint('Failed to parse color: $colorStr');
+          }
+        }
+
+        // 굵기 파싱
+        final width = (strokeData['w'] as num?)?.toDouble() ?? 2.5;
+
+        // Stroke 생성
+        final stroke = Stroke(
+          strokeId: strokeId,
+          color: color,
+          width: width,
+          points: points,
+        );
+
+        _othersStrokes[strokeId] = stroke;
+
+      } catch (e) {
+        debugPrint('❌ Failed to parse stroke: $e');
+      }
+    }
+
+    debugPrint('✅ Loaded ${_othersStrokes.length} strokes');
+    notifyListeners();
+  }
+
   /// Socket 연결 해제
   void disconnectSocket() {
     _socketService.disconnect();

--- a/pentalk_front/lib/providers/participants_provider.dart
+++ b/pentalk_front/lib/providers/participants_provider.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'dart:async';
+import '../models/participant_model.dart';
+
+/// ===============================
+/// 참여자 목록 상태 관리 Provider
+/// ===============================
+class ParticipantsProvider extends ChangeNotifier {
+  final _participantsController = StreamController<List<Participant>>.broadcast();
+  Stream<List<Participant>> get participantsStream => _participantsController.stream;
+
+  List<Participant> _participants = [];
+  List<Participant> get participants => List.unmodifiable(_participants);
+
+  int get totalCount => _participants.length;
+  int get teacherCount => _participants.where((p) => p.isTeacher).length;
+  int get studentCount => _participants.where((p) => p.isStudent).length;
+
+  /// 전체 참여자 목록 설정 (PRESENCE_STATE)
+  void setParticipants(List<Participant> participants) {
+    _participants = participants;
+    _participantsController.add(_participants);
+    notifyListeners();
+    debugPrint('👥 Participants updated: ${_participants.length} total');
+  }
+
+  /// 참여자 추가 (PRESENCE_JOIN)
+  void addParticipant(Participant participant) {
+    // 중복 체크
+    final exists = _participants.any(
+          (p) => p.userId == participant.userId && p.role == participant.role,
+    );
+
+    if (!exists) {
+      _participants.add(participant);
+      _participantsController.add(_participants);
+      notifyListeners();
+      debugPrint('✅ Participant joined: ${participant.userId} (${participant.role})');
+    }
+  }
+
+  /// 참여자 제거 (PRESENCE_LEAVE)
+  void removeParticipant(String userId, String role) {
+    final initialLength = _participants.length;
+
+    _participants.removeWhere(
+          (p) => p.userId == userId && p.role == role,
+    );
+
+    if (_participants.length < initialLength) {
+      _participantsController.add(_participants);
+      notifyListeners();
+      debugPrint('❌ Participant left: $userId ($role)');
+    }
+  }
+
+  /// 초기화
+  void clear() {
+    _participants.clear();
+    _participantsController.add(_participants);
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _participantsController.close();
+    super.dispose();
+  }
+}

--- a/pentalk_front/lib/providers/personal_drawing_provider.dart
+++ b/pentalk_front/lib/providers/personal_drawing_provider.dart
@@ -1,0 +1,275 @@
+import 'package:flutter/material.dart';
+import '../models/drawing_models.dart';
+import '../models/personal_stroke.dart';
+import '../services/local_db_service.dart';
+
+/// ===============================
+/// 개인 필기 Provider (로컬 DB 연동)
+/// ===============================
+class PersonalDrawingProvider extends ChangeNotifier {
+  final LocalDbService _dbService = LocalDbService();
+
+  // 현재 페이지 ID
+  String? _currentPageId;
+
+  // 개인 필기 데이터 (완성된 선들)
+  final Map<int, Stroke> _personalStrokes = {};
+
+  // 현재 그리는 중인 선
+  final Map<int, Stroke> _personalActiveStrokes = {};
+
+  // 개인 필기 표시 여부
+  bool _showPersonalLayer = true;
+
+  // 로딩 상태
+  bool _isLoading = false;
+
+  // Getters
+  Map<int, Stroke> get personalStrokes => _personalStrokes;
+  Map<int, Stroke> get personalActiveStrokes => _personalActiveStrokes;
+  bool get showPersonalLayer => _showPersonalLayer;
+  bool get isLoading => _isLoading;
+  String? get currentPageId => _currentPageId;
+
+  /// 모든 개인 필기 (완성 + 진행중)
+  List<Stroke> get allPersonalStrokes {
+    return [..._personalStrokes.values, ..._personalActiveStrokes.values];
+  }
+
+  /// ===============================
+  /// 페이지 로드
+  /// ===============================
+  Future<void> loadPage(String pageId) async {
+    if (_currentPageId == pageId) {
+      debugPrint('📄 Already loaded page: $pageId');
+      return;
+    }
+
+    _isLoading = true;
+    _currentPageId = pageId;
+    _personalStrokes.clear();
+    _personalActiveStrokes.clear();
+    notifyListeners();
+
+    try {
+      debugPrint('📖 Loading personal strokes for page: $pageId');
+
+      final personalStrokesList = await _dbService.getStrokesByPageId(pageId);
+
+      for (final ps in personalStrokesList) {
+        _personalStrokes[ps.strokeId] = ps.toStroke();
+      }
+
+      debugPrint('✅ Loaded ${_personalStrokes.length} personal strokes');
+    } catch (e) {
+      debugPrint('❌ Failed to load page: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  /// ===============================
+  /// 그리기 시작
+  /// ===============================
+  void startDrawing(int strokeId, DrawPoint point, Color color, double width) {
+    if (_currentPageId == null) {
+      debugPrint('⚠️ Cannot draw: No page loaded');
+      return;
+    }
+
+    final stroke = Stroke(
+      strokeId: strokeId,
+      color: color,
+      width: width,
+      points: [point],
+    );
+
+    _personalActiveStrokes[strokeId] = stroke;
+    notifyListeners();
+  }
+
+  /// ===============================
+  /// 그리기 이동
+  /// ===============================
+  void updateDrawing(int strokeId, DrawPoint point) {
+    final stroke = _personalActiveStrokes[strokeId];
+    if (stroke == null) {
+      debugPrint('⚠️ Cannot update: Stroke $strokeId not found');
+      return;
+    }
+
+    final updatedPoints = [...stroke.points, point];
+    _personalActiveStrokes[strokeId] = stroke.copyWith(points: updatedPoints);
+
+    // 3개마다 한번씩만 리렌더링 (최적화)
+    if (updatedPoints.length % 3 == 0) {
+      notifyListeners();
+    }
+  }
+
+  /// ===============================
+  /// 그리기 종료 (DB 저장)
+  /// ===============================
+  Future<void> endDrawing(int strokeId, List<DrawPoint>? refinedPoints) async {
+    if (_currentPageId == null) {
+      debugPrint('⚠️ Cannot end draw: No page loaded');
+      return;
+    }
+
+    final stroke = _personalActiveStrokes.remove(strokeId);
+    if (stroke == null) {
+      debugPrint('⚠️ Cannot end: Stroke $strokeId not found');
+      return;
+    }
+
+    // refined points가 있으면 적용
+    final finalStroke = refinedPoints != null && refinedPoints.isNotEmpty
+        ? stroke.withRefinedPoints(refinedPoints)
+        : stroke;
+
+    // 메모리에 추가
+    _personalStrokes[strokeId] = finalStroke;
+    notifyListeners();
+
+    // DB에 저장 (비동기)
+    try {
+      final personalStroke = PersonalStroke.fromStroke(
+        finalStroke,
+        _currentPageId!,
+      );
+
+      await _dbService.insertStroke(personalStroke);
+      debugPrint('💾 Saved personal stroke #$strokeId to DB');
+    } catch (e) {
+      debugPrint('❌ Failed to save stroke: $e');
+      // DB 저장 실패해도 메모리에는 있으므로 계속 사용 가능
+    }
+  }
+
+  /// ===============================
+  /// 실행 취소 (마지막 선 삭제)
+  /// ===============================
+  Future<void> undoLastStroke() async {
+    if (_personalStrokes.isEmpty) {
+      debugPrint('⚠️ No strokes to undo');
+      return;
+    }
+
+    if (_currentPageId == null) return;
+
+    // 마지막 선 찾기 (strokeId가 가장 큰 것)
+    final lastStrokeId = _personalStrokes.keys.reduce(
+          (a, b) => a > b ? a : b,
+    );
+
+    // 메모리에서 삭제
+    _personalStrokes.remove(lastStrokeId);
+    notifyListeners();
+
+    // DB에서 삭제
+    try {
+      await _dbService.deleteStroke(_currentPageId!, lastStrokeId);
+      debugPrint('🗑️ Undo: Removed stroke #$lastStrokeId');
+    } catch (e) {
+      debugPrint('❌ Failed to delete stroke from DB: $e');
+    }
+  }
+
+  /// ===============================
+  /// 특정 선 삭제
+  /// ===============================
+  Future<void> deleteStroke(int strokeId) async {
+    if (_currentPageId == null) return;
+
+    final removed = _personalStrokes.remove(strokeId) != null ||
+        _personalActiveStrokes.remove(strokeId) != null;
+
+    if (removed) {
+      notifyListeners();
+
+      try {
+        await _dbService.deleteStroke(_currentPageId!, strokeId);
+        debugPrint('🗑️ Deleted stroke #$strokeId');
+      } catch (e) {
+        debugPrint('❌ Failed to delete stroke: $e');
+      }
+    }
+  }
+
+  /// ===============================
+  /// 현재 페이지의 모든 필기 삭제
+  /// ===============================
+  Future<void> clearCurrentPage() async {
+    if (_currentPageId == null) return;
+
+    _personalStrokes.clear();
+    _personalActiveStrokes.clear();
+    notifyListeners();
+
+    try {
+      await _dbService.deleteAllStrokesInPage(_currentPageId!);
+      debugPrint('🗑️ Cleared all personal strokes in page: $_currentPageId');
+    } catch (e) {
+      debugPrint('❌ Failed to clear page: $e');
+    }
+  }
+
+  /// ===============================
+  /// 개인 레이어 토글
+  /// ===============================
+  void togglePersonalLayer() {
+    _showPersonalLayer = !_showPersonalLayer;
+    notifyListeners();
+    debugPrint('👁️ Personal layer: ${_showPersonalLayer ? 'ON' : 'OFF'}');
+  }
+
+  void setPersonalLayerVisible(bool visible) {
+    if (_showPersonalLayer != visible) {
+      _showPersonalLayer = visible;
+      notifyListeners();
+    }
+  }
+
+  /// ===============================
+  /// 통계
+  /// ===============================
+  Future<int> getTotalStrokeCount() async {
+    return await _dbService.getTotalStrokeCount();
+  }
+
+  Future<Map<String, int>> getStrokeCountByPage() async {
+    return await _dbService.getStrokeCountByPage();
+  }
+
+  Future<List<String>> getAllPages() async {
+    return await _dbService.getAllPageIds();
+  }
+
+  /// ===============================
+  /// 정리
+  /// ===============================
+
+  /// 30일 이상 된 필기 삭제
+  Future<int> cleanupOldStrokes({int days = 30}) async {
+    final cutoffDate = DateTime.now().subtract(Duration(days: days));
+    return await _dbService.deleteStrokesOlderThan(cutoffDate);
+  }
+
+  /// 전체 개인 필기 삭제 (초기화)
+  Future<void> deleteAllPersonalStrokes() async {
+    _personalStrokes.clear();
+    _personalActiveStrokes.clear();
+    _currentPageId = null;
+    notifyListeners();
+
+    await _dbService.deleteAllStrokes();
+    debugPrint('💥 Deleted all personal strokes');
+  }
+
+  @override
+  void dispose() {
+    _dbService.close();
+    super.dispose();
+  }
+}

--- a/pentalk_front/lib/screens/drawing_screen.dart
+++ b/pentalk_front/lib/screens/drawing_screen.dart
@@ -1,3 +1,4 @@
+// lib/screens/drawing_screen.dart
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -16,6 +17,8 @@ class DrawingScreen extends StatefulWidget {
   final String? serverUrl;
   final String? roomId;
   final String? userId;
+  final bool isReadOnly;  // ✅ 읽기 전용 모드
+  final String? sessionId;  // ✅ 저장된 세션 ID (읽기 전용 시 사용)
 
   const DrawingScreen({
     Key? key,
@@ -25,6 +28,8 @@ class DrawingScreen extends StatefulWidget {
     this.serverUrl,
     this.roomId,
     this.userId,
+    this.isReadOnly = false,  // ✅ 기본값: 편집 가능
+    this.sessionId,  // ✅ 읽기 전용 시 필수
   }) : super(key: key);
 
   @override
@@ -49,6 +54,65 @@ class _DrawingScreenState extends State<DrawingScreen> {
 
     // 배경 설정
     provider.setBackgroundUrl(widget.backgroundUrl);
+
+    // ========================================
+    // ✅ 읽기 전용 모드: 저장된 판서 데이터 로드
+    // ========================================
+    if (widget.isReadOnly && widget.sessionId != null) {
+      debugPrint('📖 Loading saved whiteboard: ${widget.sessionId}');
+
+      try {
+        setState(() {
+          _isConnecting = true;
+        });
+
+        final response = await ApiService.getWhiteboard(
+          sessionId: widget.sessionId!,
+        );
+
+        if (response.success && response.data != null) {
+          // 판서 데이터 로드
+          provider.loadSavedStrokes(response.data!.strokes);
+
+          debugPrint('✅ Whiteboard loaded: ${response.data!.strokes.length} strokes');
+          debugPrint('📖 Read-only mode: ${response.data!.readOnly}');
+        } else {
+          debugPrint('❌ Failed to load whiteboard: ${response.message}');
+
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('판서 데이터 로드 실패: ${response.message ?? "알 수 없는 오류"}'),
+                backgroundColor: Colors.red,
+              ),
+            );
+          }
+        }
+      } catch (e) {
+        debugPrint('❌ Load whiteboard error: $e');
+
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('오류: $e'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      } finally {
+        if (mounted) {
+          setState(() {
+            _isConnecting = false;
+          });
+        }
+      }
+
+      return; // 읽기 전용 모드는 여기서 종료
+    }
+
+    // ========================================
+    // 편집 가능 모드 (기존 로직)
+    // ========================================
 
     // 그리기 모드 (교사는 기본 활성화)
     if (widget.isTeacher) {
@@ -244,61 +308,93 @@ class _DrawingScreenState extends State<DrawingScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.materialTitle),
-        actions: [
-          // 교사용 컨트롤
-          if (widget.isTeacher) ...[
-            // 펜 색상 선택
-            IconButton(
-              icon: Consumer<DrawingProvider>(
-                builder: (context, provider, child) {
-                  return Container(
-                    width: 24,
-                    height: 24,
-                    decoration: BoxDecoration(
-                      color: provider.currentColor,
-                      shape: BoxShape.circle,
-                      border: Border.all(color: Colors.grey),
+        title: Row(
+          children: [
+            Expanded(child: Text(widget.materialTitle)),
+            // ✅ 읽기 전용 배지
+            if (widget.isReadOnly)
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: Colors.orange[100],
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: Colors.orange, width: 1),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.visibility, size: 16, color: Colors.orange[800]),
+                    const SizedBox(width: 4),
+                    Text(
+                      '읽기 전용',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.orange[800],
+                      ),
                     ),
-                  );
-                },
+                  ],
+                ),
               ),
-              onPressed: _showColorPicker,
-              tooltip: '색상 선택',
-            ),
-            // 펜 굵기 선택
-            IconButton(
-              icon: const Icon(Icons.line_weight),
-              onPressed: _showWidthPicker,
-              tooltip: '굵기 선택',
-            ),
-            // Undo (최근 선 삭제)
-            IconButton(
-              icon: const Icon(Icons.undo),
-              onPressed: _handleUndo,
-              tooltip: '실행 취소',
-            ),
-            // 전체 지우기
-            IconButton(
-              icon: const Icon(Icons.delete_outline),
-              onPressed: _handleClear,
-              tooltip: '전체 지우기',
-            ),
           ],
-
+        ),
+        actions: [
           // ========================================
-          // ✅ 참여자 버튼 추가! (교사/학생 모두 표시)
+          // ✅ 읽기 전용 모드에서는 편집 버튼 모두 숨김!
           // ========================================
-          const ParticipantsButton(),
+          if (!widget.isReadOnly) ...[
+            // 교사용 컨트롤
+            if (widget.isTeacher) ...[
+              // 펜 색상 선택
+              IconButton(
+                icon: Consumer<DrawingProvider>(
+                  builder: (context, provider, child) {
+                    return Container(
+                      width: 24,
+                      height: 24,
+                      decoration: BoxDecoration(
+                        color: provider.currentColor,
+                        shape: BoxShape.circle,
+                        border: Border.all(color: Colors.grey),
+                      ),
+                    );
+                  },
+                ),
+                onPressed: _showColorPicker,
+                tooltip: '색상 선택',
+              ),
+              // 펜 굵기 선택
+              IconButton(
+                icon: const Icon(Icons.line_weight),
+                onPressed: _showWidthPicker,
+                tooltip: '굵기 선택',
+              ),
+              // Undo (최근 선 삭제)
+              IconButton(
+                icon: const Icon(Icons.undo),
+                onPressed: _handleUndo,
+                tooltip: '실행 취소',
+              ),
+              // 전체 지우기
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                onPressed: _handleClear,
+                tooltip: '전체 지우기',
+              ),
+            ],
 
-          // 세션 종료 버튼 (교사만)
-          if (widget.isTeacher)
-            IconButton(
-              icon: const Icon(Icons.logout),
-              onPressed: _endSession,
-              tooltip: '세션 종료',
-              color: Colors.red,
-            ),
+            // 참여자 버튼 (편집 모드에서만)
+            const ParticipantsButton(),
+
+            // 세션 종료 버튼 (교사만)
+            if (widget.isTeacher)
+              IconButton(
+                icon: const Icon(Icons.logout),
+                onPressed: _endSession,
+                tooltip: '세션 종료',
+                color: Colors.red,
+              ),
+          ],
         ],
       ),
       body: _isConnecting
@@ -317,7 +413,10 @@ class _DrawingScreenState extends State<DrawingScreen> {
       ),
       // 교사용: 그리기/이동 모드 토글
       // 학생용: 내 필기 보기/끄기 + 그리기/이동 모드 토글
-      floatingActionButton: widget.isTeacher
+      // ✅ 읽기 전용: 버튼 없음 (스크롤/줌만 가능)
+      floatingActionButton: widget.isReadOnly
+          ? null  // ✅ 읽기 전용 모드에서는 버튼 없음
+          : widget.isTeacher
           ? Consumer<DrawingProvider>(
         builder: (context, provider, child) {
           return Column(

--- a/pentalk_front/lib/screens/drawing_screen.dart
+++ b/pentalk_front/lib/screens/drawing_screen.dart
@@ -5,6 +5,8 @@ import 'package:provider/provider.dart';
 import '../providers/drawing_provider.dart';
 import '../providers/personal_drawing_provider.dart';
 import '../widgets/drawing_canvas_widget.dart';
+import '../widgets/session_ended_dialog.dart';
+import '../services/api_service.dart';
 
 class DrawingScreen extends StatefulWidget {
   final String materialTitle;
@@ -36,6 +38,7 @@ class _DrawingScreenState extends State<DrawingScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _initializeDrawing();
+      _setupSessionEndedListener();
     });
   }
 
@@ -67,6 +70,46 @@ class _DrawingScreenState extends State<DrawingScreen> {
       debugPrint('roomId: ${widget.roomId}');
       debugPrint('userId: ${widget.userId}');
     }
+  }
+
+  /// 세션 종료 이벤트 리스너 설정
+  void _setupSessionEndedListener() {
+    final provider = context.read<DrawingProvider>();
+
+    provider.onSessionEnded = (data) {
+      _handleSessionEnded(data);
+    };
+  }
+
+  /// 세션 종료 이벤트 처리
+  void _handleSessionEnded(Map<String, dynamic> data) {
+    final message = data['message'] as String? ?? '교사가 수업을 종료했습니다';
+
+    if (widget.isTeacher) {
+      // 교사: 팝업 없이 바로 홈으로
+      _cleanupAndGoHome();
+    } else {
+      // 학생: 알림 팝업 표시
+      SessionEndedDialog.showStudentNotification(
+        context,
+        message: message,
+        onConfirm: _cleanupAndGoHome,
+      );
+    }
+  }
+
+  /// 정리 후 홈 화면으로 이동
+  void _cleanupAndGoHome() {
+    final provider = context.read<DrawingProvider>();
+
+    // 소켓 연결 해제
+    provider.disconnectSocket();
+
+    // 상태 초기화
+    provider.clear();
+
+    // 홈으로 이동
+    Navigator.popUntil(context, (route) => route.isFirst);
   }
 
   Future<void> _connectSocket() async {
@@ -106,6 +149,55 @@ class _DrawingScreenState extends State<DrawingScreen> {
           _isConnecting = false;
         });
       }
+    }
+  }
+
+  /// 세션 종료 (교사 전용)
+  Future<void> _endSession() async {
+    if (!widget.isTeacher) return;
+
+    // 확인 팝업
+    final confirmed = await SessionEndedDialog.showEndConfirmation(context);
+    if (!confirmed) return;
+
+    // 로딩 팝업 표시
+    SessionEndedDialog.showEndingProgress(context);
+
+    try {
+      // API 호출
+      final response = await ApiService.endSession(
+        sessionId: widget.roomId!,
+      );
+
+      if (!mounted) return;
+
+      // 로딩 팝업 닫기
+      Navigator.pop(context);
+
+      if (response.success) {
+        debugPrint('✅ Session ended successfully');
+        // session:ended 이벤트를 받으면 자동으로 처리됨
+      } else {
+        // 에러 처리
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('세션 종료 실패: ${response.message}'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+
+      // 로딩 팝업 닫기
+      Navigator.pop(context);
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('오류: $e'),
+          backgroundColor: Colors.red,
+        ),
+      );
     }
   }
 
@@ -159,6 +251,13 @@ class _DrawingScreenState extends State<DrawingScreen> {
               icon: const Icon(Icons.delete_outline),
               onPressed: _handleClear,
               tooltip: '전체 지우기',
+            ),
+            // 👇 세션 종료 버튼 추가!
+            IconButton(
+              icon: const Icon(Icons.logout),
+              onPressed: _endSession,
+              tooltip: '세션 종료',
+              color: Colors.red,
             ),
           ],
         ],

--- a/pentalk_front/lib/screens/drawing_screen.dart
+++ b/pentalk_front/lib/screens/drawing_screen.dart
@@ -1,20 +1,21 @@
-// lib/screens/drawing_screen.dart
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/drawing_provider.dart';
 import '../providers/personal_drawing_provider.dart';
+import '../providers/participants_provider.dart';
 import '../widgets/drawing_canvas_widget.dart';
 import '../widgets/session_ended_dialog.dart';
+import '../widgets/participants_button.dart';
 import '../services/api_service.dart';
 
 class DrawingScreen extends StatefulWidget {
   final String materialTitle;
-  final String? backgroundUrl; // PDF/이미지 URL (선택)
+  final String? backgroundUrl;
   final bool isTeacher;
-  final String? serverUrl; // Socket.IO 서버 URL
-  final String? roomId; // 방 ID
-  final String? userId; // 사용자 ID
+  final String? serverUrl;
+  final String? roomId;
+  final String? userId;
 
   const DrawingScreen({
     Key? key,
@@ -39,6 +40,7 @@ class _DrawingScreenState extends State<DrawingScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _initializeDrawing();
       _setupSessionEndedListener();
+      _setupPresenceCallbacks(); // ✅ 이미 추가되어 있음
     });
   }
 
@@ -79,6 +81,36 @@ class _DrawingScreenState extends State<DrawingScreen> {
     provider.onSessionEnded = (data) {
       _handleSessionEnded(data);
     };
+  }
+
+  /// ===============================
+  /// ✅ Presence 콜백 설정 (신규 메서드!)
+  /// ===============================
+  void _setupPresenceCallbacks() {
+    final drawingProvider = context.read<DrawingProvider>();
+    final participantsProvider = context.read<ParticipantsProvider>();
+
+    final socketService = drawingProvider.socketService;
+
+    // PRESENCE_STATE 콜백
+    socketService.onPresenceState = (participants) {
+      participantsProvider.setParticipants(participants);
+      debugPrint('👥 Presence state updated: ${participants.length} participants');
+    };
+
+    // PRESENCE_JOIN 콜백
+    socketService.onPresenceJoin = (participant) {
+      participantsProvider.addParticipant(participant);
+      debugPrint('✅ Participant joined: ${participant.userId} (${participant.role})');
+    };
+
+    // PRESENCE_LEAVE 콜백
+    socketService.onPresenceLeave = (userId, role) {
+      participantsProvider.removeParticipant(userId, role);
+      debugPrint('❌ Participant left: $userId ($role)');
+    };
+
+    debugPrint('🔔 Presence callbacks setup completed');
   }
 
   /// 세션 종료 이벤트 처리
@@ -252,14 +284,21 @@ class _DrawingScreenState extends State<DrawingScreen> {
               onPressed: _handleClear,
               tooltip: '전체 지우기',
             ),
-            // 👇 세션 종료 버튼 추가!
+          ],
+
+          // ========================================
+          // ✅ 참여자 버튼 추가! (교사/학생 모두 표시)
+          // ========================================
+          const ParticipantsButton(),
+
+          // 세션 종료 버튼 (교사만)
+          if (widget.isTeacher)
             IconButton(
               icon: const Icon(Icons.logout),
               onPressed: _endSession,
               tooltip: '세션 종료',
               color: Colors.red,
             ),
-          ],
         ],
       ),
       body: _isConnecting

--- a/pentalk_front/lib/screens/login_screen.dart
+++ b/pentalk_front/lib/screens/login_screen.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import '../services/api_service.dart';
+import '../services/auth_service.dart';
+
+/// ===============================
+/// 로그인 화면
+/// ===============================
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({Key? key}) : super(key: key);
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _userIdController = TextEditingController();
+  String _selectedRole = 'student'; // 기본값: 학생
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _userIdController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleLogin() async {
+    final userId = _userIdController.text.trim();
+
+    if (userId.isEmpty) {
+      _showError('사용자 ID를 입력해주세요');
+      return;
+    }
+
+    setState(() => _isLoading = true);
+
+    try {
+      // 로그인 API 호출
+      final response = await ApiService.login(
+        userId: userId,
+        role: _selectedRole,
+      );
+
+      if (!mounted) return;
+
+      if (response.success && response.data != null) {
+        // 토큰 저장
+        await AuthService.saveUserInfo(
+          userId: response.data!.userId,
+          role: response.data!.role,
+          token: response.data!.token,
+        );
+
+        // 홈 화면으로 이동
+        Navigator.pushReplacementNamed(context, '/home');
+      } else {
+        _showError(response.message ?? '로그인 실패');
+      }
+    } catch (e) {
+      if (!mounted) return;
+      _showError('네트워크 오류: $e');
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  void _showError(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: Colors.red,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // 로고/제목
+                const Icon(
+                  Icons.school,
+                  size: 80,
+                  color: Colors.blue,
+                ),
+                const SizedBox(height: 24),
+                const Text(
+                  'PenTalk',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 32,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  '하이브리드 교실',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: Colors.grey,
+                  ),
+                ),
+                const SizedBox(height: 48),
+
+                // 사용자 ID 입력
+                TextField(
+                  controller: _userIdController,
+                  decoration: InputDecoration(
+                    labelText: '사용자 ID',
+                    hintText: 'teacher_test 또는 student_01',
+                    prefixIcon: const Icon(Icons.person),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  enabled: !_isLoading,
+                  onSubmitted: (_) => _handleLogin(),
+                ),
+                const SizedBox(height: 24),
+
+                // 역할 선택
+                const Text(
+                  '역할 선택',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: RadioListTile<String>(
+                        title: const Text('학생'),
+                        value: 'student',
+                        groupValue: _selectedRole,
+                        onChanged: _isLoading
+                            ? null
+                            : (value) {
+                          setState(() => _selectedRole = value!);
+                        },
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          side: BorderSide(
+                            color: _selectedRole == 'student'
+                                ? Colors.blue
+                                : Colors.grey[300]!,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: RadioListTile<String>(
+                        title: const Text('교사'),
+                        value: 'teacher',
+                        groupValue: _selectedRole,
+                        onChanged: _isLoading
+                            ? null
+                            : (value) {
+                          setState(() => _selectedRole = value!);
+                        },
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          side: BorderSide(
+                            color: _selectedRole == 'teacher'
+                                ? Colors.blue
+                                : Colors.grey[300]!,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 32),
+
+                // 로그인 버튼
+                ElevatedButton(
+                  onPressed: _isLoading ? null : _handleLogin,
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: _isLoading
+                      ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.white,
+                    ),
+                  )
+                      : const Text(
+                    '로그인',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+
+                // 안내 문구
+                Text(
+                  '개발 모드: 비밀번호 없이 로그인',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Colors.grey[600],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pentalk_front/lib/services/api_service.dart
+++ b/pentalk_front/lib/services/api_service.dart
@@ -1,0 +1,186 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter/foundation.dart';
+import '../models/drawing_models.dart';
+import 'auth_service.dart';
+
+/// ===============================
+/// REST API 클라이언트 서비스
+/// 판서 데이터 저장/불러오기
+/// ===============================
+class ApiService {
+  // 서버 베이스 URL (개발 환경)
+  static const String baseUrl = 'http://localhost:3000';
+
+  /// ===============================
+  /// 판서 데이터 저장 (POST /strokes)
+  /// ===============================
+  static Future<ApiResponse> saveStrokes({
+    required String sessionId,
+    required List<Stroke> strokes,
+  }) async {
+    try {
+      // JWT 토큰 가져오기
+      final token = await AuthService.getToken();
+
+      // Stroke → JSON 변환
+      final strokesJson = strokes.map((stroke) => {
+        'sId': stroke.id,
+        'pts': stroke.points.map((p) => {
+          'x': p.x,
+          'y': p.y,
+        }).toList(),
+        'c': stroke.color,
+        'w': stroke.width,
+      }).toList();
+
+      final body = {
+        'sessionId': sessionId,
+        'strokes': strokesJson,
+      };
+
+      debugPrint('📤 POST /strokes: ${strokes.length} strokes');
+
+      // HTTP 요청
+      final response = await http.post(
+        Uri.parse('$baseUrl/strokes'),
+        headers: {
+          'Content-Type': 'application/json',
+          if (token != null) 'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode(body),
+      ).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          throw TimeoutException('Request timeout');
+        },
+      );
+
+      // 응답 처리
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final data = jsonDecode(response.body);
+        debugPrint('✅ Saved ${data['count']} strokes');
+
+        return ApiResponse(
+          success: true,
+          data: data,
+        );
+      } else {
+        final error = jsonDecode(response.body);
+        debugPrint('❌ Save failed: ${error['message']}');
+
+        return ApiResponse(
+          success: false,
+          error: error['error'] ?? 'UNKNOWN_ERROR',
+          message: error['message'] ?? 'Failed to save strokes',
+        );
+      }
+    } catch (e) {
+      debugPrint('❌ API error: $e');
+      return ApiResponse(
+        success: false,
+        error: 'NETWORK_ERROR',
+        message: e.toString(),
+      );
+    }
+  }
+
+  /// ===============================
+  /// 판서 데이터 불러오기 (GET /strokes)
+  /// ===============================
+  static Future<ApiResponse<List<Stroke>>> loadStrokes({
+    required String sessionId,
+  }) async {
+    try {
+      // JWT 토큰 가져오기
+      final token = await AuthService.getToken();
+
+      debugPrint('📥 GET /strokes?sessionId=$sessionId');
+
+      // HTTP 요청
+      final response = await http.get(
+        Uri.parse('$baseUrl/strokes?sessionId=$sessionId'),
+        headers: {
+          'Content-Type': 'application/json',
+          if (token != null) 'Authorization': 'Bearer $token',
+        },
+      ).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          throw TimeoutException('Request timeout');
+        },
+      );
+
+      // 응답 처리
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        final strokesJson = data['strokes'] as List;
+
+        // JSON → Stroke 변환
+        final strokes = strokesJson.map((json) {
+          final points = (json['pts'] as List).map((p) =>
+              DrawPoint(p['x'], p['y'])
+          ).toList();
+
+          return Stroke(
+            id: json['sId'],
+            points: points,
+            color: json['c'],
+            width: json['w'],
+          );
+        }).toList();
+
+        debugPrint('✅ Loaded ${strokes.length} strokes');
+
+        return ApiResponse<List<Stroke>>(
+          success: true,
+          data: strokes,
+        );
+      } else {
+        final error = jsonDecode(response.body);
+        debugPrint('❌ Load failed: ${error['message']}');
+
+        return ApiResponse<List<Stroke>>(
+          success: false,
+          error: error['error'] ?? 'UNKNOWN_ERROR',
+          message: error['message'] ?? 'Failed to load strokes',
+        );
+      }
+    } catch (e) {
+      debugPrint('❌ API error: $e');
+      return ApiResponse<List<Stroke>>(
+        success: false,
+        error: 'NETWORK_ERROR',
+        message: e.toString(),
+      );
+    }
+  }
+}
+
+/// ===============================
+/// API 응답 모델
+/// ===============================
+class ApiResponse<T> {
+  final bool success;
+  final T? data;
+  final String? error;
+  final String? message;
+
+  ApiResponse({
+    required this.success,
+    this.data,
+    this.error,
+    this.message,
+  });
+}
+
+/// ===============================
+/// 타임아웃 예외
+/// ===============================
+class TimeoutException implements Exception {
+  final String message;
+  TimeoutException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/pentalk_front/lib/services/api_service.dart
+++ b/pentalk_front/lib/services/api_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';  // Color 사용
 import '../models/drawing_models.dart';
 import 'auth_service.dart';
 
@@ -25,12 +26,12 @@ class ApiService {
 
       // Stroke → JSON 변환
       final strokesJson = strokes.map((stroke) => {
-        'sId': stroke.id,
+        'sId': stroke.strokeId,  // id → strokeId
         'pts': stroke.points.map((p) => {
           'x': p.x,
           'y': p.y,
         }).toList(),
-        'c': stroke.color,
+        'c': '#${stroke.color.value.toRadixString(16).padLeft(8, '0').substring(2)}',
         'w': stroke.width,
       }).toList();
 
@@ -119,14 +120,22 @@ class ApiService {
         // JSON → Stroke 변환
         final strokes = strokesJson.map((json) {
           final points = (json['pts'] as List).map((p) =>
-              DrawPoint(p['x'], p['y'])
+              DrawPoint(
+                x: (p['x'] as num).toDouble(),
+                y: (p['y'] as num).toDouble(),
+              )
           ).toList();
 
+          // 색상 파싱 (#RRGGBB → Color)
+          final colorString = json['c'] as String;
+          final colorInt = int.parse(colorString.replaceFirst('#', ''), radix: 16);
+          final color = Color(0xFF000000 | colorInt);
+
           return Stroke(
-            id: json['sId'],
+            strokeId: json['sId'] as int,
             points: points,
-            color: json['c'],
-            width: json['w'],
+            color: color,
+            width: (json['w'] as num).toDouble(),
           );
         }).toList();
 
@@ -155,6 +164,83 @@ class ApiService {
       );
     }
   }
+
+  /// ===============================
+  /// 로그인 (POST /auth/dev-login)
+  /// ===============================
+  static Future<ApiResponse<LoginResponse>> login({
+    required String userId,
+    required String role,
+  }) async {
+    try {
+      debugPrint('📤 POST /auth/dev-login: userId=$userId, role=$role');
+
+      final body = {
+        'userId': userId,
+        'role': role,
+      };
+
+      // HTTP 요청
+      final response = await http.post(
+        Uri.parse('$baseUrl/auth/dev-login'),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode(body),
+      ).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          throw TimeoutException('Login timeout');
+        },
+      );
+
+      // 응답 처리
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        debugPrint('✅ Login success: ${data['user']['userId']}');
+
+        return ApiResponse<LoginResponse>(
+          success: true,
+          data: LoginResponse(
+            token: data['token'],
+            userId: data['user']['userId'],
+            role: data['user']['role'],
+          ),
+        );
+      } else {
+        final error = jsonDecode(response.body);
+        debugPrint('❌ Login failed: ${error['message']}');
+
+        return ApiResponse<LoginResponse>(
+          success: false,
+          error: error['code'] ?? 'LOGIN_FAILED',
+          message: error['message'] ?? 'Login failed',
+        );
+      }
+    } catch (e) {
+      debugPrint('❌ Login error: $e');
+      return ApiResponse<LoginResponse>(
+        success: false,
+        error: 'NETWORK_ERROR',
+        message: e.toString(),
+      );
+    }
+  }
+}
+
+/// ===============================
+/// 로그인 응답 모델
+/// ===============================
+class LoginResponse {
+  final String token;
+  final String userId;
+  final String role;
+
+  LoginResponse({
+    required this.token,
+    required this.userId,
+    required this.role,
+  });
 }
 
 /// ===============================

--- a/pentalk_front/lib/services/api_service.dart
+++ b/pentalk_front/lib/services/api_service.dart
@@ -226,6 +226,87 @@ class ApiService {
       );
     }
   }
+
+  /// ===============================
+  /// 세션 종료 (POST /sessions/{sessionId}/end)
+  /// 교사 전용
+  /// ===============================
+  static Future<ApiResponse<EndSessionResponse>> endSession({
+    required String sessionId,
+  }) async {
+    try {
+      // JWT 토큰 가져오기
+      final token = await AuthService.getToken();
+
+      debugPrint('📤 POST /sessions/$sessionId/end');
+
+      // HTTP 요청
+      final response = await http.post(
+        Uri.parse('$baseUrl/sessions/$sessionId/end'),
+        headers: {
+          'Content-Type': 'application/json',
+          if (token != null) 'Authorization': 'Bearer $token',
+        },
+      ).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          throw TimeoutException('Request timeout');
+        },
+      );
+
+      // 응답 처리
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        debugPrint('✅ Session ended: ${data['sessionId']}');
+
+        return ApiResponse<EndSessionResponse>(
+          success: data['ok'] ?? false,
+          data: EndSessionResponse(
+            sessionId: data['sessionId'],
+            status: data['status'],
+            strokeCount: data['strokeCount'],
+            drawingPath: data['drawingPath'],
+            closedAt: data['closedAt'],
+          ),
+        );
+      } else {
+        final error = jsonDecode(response.body);
+        debugPrint('❌ End session failed: ${error['message']}');
+
+        return ApiResponse<EndSessionResponse>(
+          success: false,
+          error: error['code'] ?? 'END_SESSION_FAILED',
+          message: error['message'] ?? 'Failed to end session',
+        );
+      }
+    } catch (e) {
+      debugPrint('❌ End session error: $e');
+      return ApiResponse<EndSessionResponse>(
+        success: false,
+        error: 'NETWORK_ERROR',
+        message: e.toString(),
+      );
+    }
+  }
+}
+
+/// ===============================
+/// 세션 종료 응답 모델
+/// ===============================
+class EndSessionResponse {
+  final String sessionId;
+  final String status;
+  final int strokeCount;
+  final String drawingPath;
+  final String closedAt;
+
+  EndSessionResponse({
+    required this.sessionId,
+    required this.status,
+    required this.strokeCount,
+    required this.drawingPath,
+    required this.closedAt,
+  });
 }
 
 /// ===============================

--- a/pentalk_front/lib/services/api_service.dart
+++ b/pentalk_front/lib/services/api_service.dart
@@ -288,6 +288,68 @@ class ApiService {
       );
     }
   }
+
+  /// ===============================
+  /// 판서 데이터 조회 (GET /sessions/{sessionId}/whiteboard)
+  /// 읽기 전용 뷰어용
+  /// ===============================
+  static Future<ApiResponse<WhiteboardData>> getWhiteboard({
+    required String sessionId,
+  }) async {
+    try {
+      // JWT 토큰 가져오기
+      final token = await AuthService.getToken();
+
+      debugPrint('📤 GET /sessions/$sessionId/whiteboard');
+
+      // HTTP 요청
+      final response = await http.get(
+        Uri.parse('$baseUrl/sessions/$sessionId/whiteboard'),
+        headers: {
+          'Content-Type': 'application/json',
+          if (token != null) 'Authorization': 'Bearer $token',
+        },
+      ).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          throw TimeoutException('Request timeout');
+        },
+      );
+
+      // 응답 처리
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        debugPrint('✅ Whiteboard loaded: ${data['strokes']?.length ?? 0} strokes');
+
+        return ApiResponse<WhiteboardData>(
+          success: true,
+          data: WhiteboardData(
+            sessionId: data['sessionId'],
+            readOnly: data['readOnly'] ?? true,
+            strokes: (data['strokes'] as List?)
+                ?.map((e) => Map<String, dynamic>.from(e as Map))
+                .toList() ?? [],
+          ),
+        );
+      } else {
+        final error = jsonDecode(response.body);
+        debugPrint('❌ Get whiteboard failed: ${error['message']}');
+
+        return ApiResponse<WhiteboardData>(
+          success: false,
+          error: error['code'] ?? 'GET_WHITEBOARD_FAILED',
+          message: error['message'] ?? 'Failed to get whiteboard',
+        );
+      }
+    } catch (e) {
+      debugPrint('❌ Get whiteboard error: $e');
+      return ApiResponse<WhiteboardData>(
+        success: false,
+        error: 'NETWORK_ERROR',
+        message: e.toString(),
+      );
+    }
+  }
 }
 
 /// ===============================
@@ -321,6 +383,21 @@ class LoginResponse {
     required this.token,
     required this.userId,
     required this.role,
+  });
+}
+
+/// ===============================
+/// Whiteboard 데이터 모델
+/// ===============================
+class WhiteboardData {
+  final String sessionId;
+  final bool readOnly;
+  final List<Map<String, dynamic>> strokes;
+
+  WhiteboardData({
+    required this.sessionId,
+    required this.readOnly,
+    required this.strokes,
   });
 }
 

--- a/pentalk_front/lib/services/auth_service.dart
+++ b/pentalk_front/lib/services/auth_service.dart
@@ -1,0 +1,72 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/foundation.dart';
+
+/// ===============================
+/// 인증 토큰 관리 서비스
+/// JWT 토큰 저장/로드
+/// ===============================
+class AuthService {
+  static const String _tokenKey = 'jwt_token';
+  static const String _userIdKey = 'user_id';
+  static const String _roleKey = 'user_role';
+
+  /// JWT 토큰 저장
+  static Future<void> saveToken(String token) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_tokenKey, token);
+    debugPrint('✅ JWT Token saved');
+  }
+
+  /// JWT 토큰 가져오기
+  static Future<String?> getToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_tokenKey);
+  }
+
+  /// 사용자 정보 저장 (로그인 시)
+  static Future<void> saveUserInfo({
+    required String userId,
+    required String role,
+    required String token,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_tokenKey, token);
+    await prefs.setString(_userIdKey, userId);
+    await prefs.setString(_roleKey, role);
+    debugPrint('✅ User info saved: $userId ($role)');
+  }
+
+  /// 사용자 ID 가져오기
+  static Future<String?> getUserId() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_userIdKey);
+  }
+
+  /// 사용자 Role 가져오기 (teacher/student)
+  static Future<String?> getRole() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_roleKey);
+  }
+
+  /// 로그인 여부 확인
+  static Future<bool> isLoggedIn() async {
+    final token = await getToken();
+    return token != null && token.isNotEmpty;
+  }
+
+  /// 로그아웃 (토큰 삭제)
+  static Future<void> logout() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_tokenKey);
+    await prefs.remove(_userIdKey);
+    await prefs.remove(_roleKey);
+    debugPrint('✅ Logged out');
+  }
+
+  /// 전체 삭제 (앱 초기화용)
+  static Future<void> clearAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+    debugPrint('✅ All data cleared');
+  }
+}

--- a/pentalk_front/lib/services/auth_service.dart
+++ b/pentalk_front/lib/services/auth_service.dart
@@ -1,26 +1,27 @@
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter/foundation.dart';
 
 /// ===============================
-/// 인증 토큰 관리 서비스
-/// JWT 토큰 저장/로드
+/// 인증 서비스 (보안 강화)
+/// flutter_secure_storage 사용
 /// ===============================
 class AuthService {
+  static const _storage = FlutterSecureStorage();
+
+  // Key 상수
   static const String _tokenKey = 'jwt_token';
   static const String _userIdKey = 'user_id';
   static const String _roleKey = 'user_role';
 
   /// JWT 토큰 저장
   static Future<void> saveToken(String token) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_tokenKey, token);
-    debugPrint('✅ JWT Token saved');
+    await _storage.write(key: _tokenKey, value: token);
+    debugPrint('✅ JWT Token saved (secure)');
   }
 
   /// JWT 토큰 가져오기
   static Future<String?> getToken() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_tokenKey);
+    return await _storage.read(key: _tokenKey);
   }
 
   /// 사용자 정보 저장 (로그인 시)
@@ -29,23 +30,20 @@ class AuthService {
     required String role,
     required String token,
   }) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_tokenKey, token);
-    await prefs.setString(_userIdKey, userId);
-    await prefs.setString(_roleKey, role);
-    debugPrint('✅ User info saved: $userId ($role)');
+    await _storage.write(key: _tokenKey, value: token);
+    await _storage.write(key: _userIdKey, value: userId);
+    await _storage.write(key: _roleKey, value: role);
+    debugPrint('✅ User info saved (secure): $userId ($role)');
   }
 
   /// 사용자 ID 가져오기
   static Future<String?> getUserId() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_userIdKey);
+    return await _storage.read(key: _userIdKey);
   }
 
   /// 사용자 Role 가져오기 (teacher/student)
   static Future<String?> getRole() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_roleKey);
+    return await _storage.read(key: _roleKey);
   }
 
   /// 로그인 여부 확인
@@ -56,17 +54,15 @@ class AuthService {
 
   /// 로그아웃 (토큰 삭제)
   static Future<void> logout() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_tokenKey);
-    await prefs.remove(_userIdKey);
-    await prefs.remove(_roleKey);
-    debugPrint('✅ Logged out');
+    await _storage.delete(key: _tokenKey);
+    await _storage.delete(key: _userIdKey);
+    await _storage.delete(key: _roleKey);
+    debugPrint('✅ Logged out (secure)');
   }
 
   /// 전체 삭제 (앱 초기화용)
   static Future<void> clearAll() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.clear();
-    debugPrint('✅ All data cleared');
+    await _storage.deleteAll();
+    debugPrint('✅ All data cleared (secure)');
   }
 }

--- a/pentalk_front/lib/services/deep_link_service.dart
+++ b/pentalk_front/lib/services/deep_link_service.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:app_links/app_links.dart';
+
+/// ===============================
+/// Deep Link 처리 서비스
+/// pentalk://material/{sessionId}/{materialId}
+/// ===============================
+class DeepLinkService {
+  static final DeepLinkService _instance = DeepLinkService._internal();
+  factory DeepLinkService() => _instance;
+  DeepLinkService._internal();
+
+  final _appLinks = AppLinks();
+
+  /// Deep Link 데이터
+  String? initialLink;
+
+  /// 앱 시작 시 초기 링크 확인
+  Future<String?> getInitialLink() async {
+    try {
+      final uri = await _appLinks.getInitialLink();
+      if (uri != null) {
+        debugPrint('📱 Initial Deep Link: $uri');
+        initialLink = uri.toString();
+        return initialLink;
+      }
+    } catch (e) {
+      debugPrint('❌ Failed to get initial link: $e');
+    }
+    return null;
+  }
+
+  /// 백그라운드에서 복귀 시 링크 감지
+  Stream<Uri> get uriLinkStream => _appLinks.uriLinkStream;
+
+  /// URL 파싱: pentalk://material/{sessionId}/{materialId}
+  Map<String, String>? parseMaterialLink(String uriString) {
+    try {
+      final uri = Uri.parse(uriString);
+
+      // scheme 확인
+      if (uri.scheme != 'pentalk') {
+        debugPrint('⚠️ Invalid scheme: ${uri.scheme}');
+        return null;
+      }
+
+      // path 파싱: /material/s1/m1
+      final pathSegments = uri.pathSegments;
+
+      if (pathSegments.isEmpty) {
+        debugPrint('⚠️ Empty path');
+        return null;
+      }
+
+      // material 링크인지 확인
+      if (pathSegments[0] == 'material' && pathSegments.length >= 3) {
+        final sessionId = pathSegments[1];
+        final materialId = pathSegments[2];
+
+        debugPrint('✅ Parsed: sessionId=$sessionId, materialId=$materialId');
+
+        return {
+          'sessionId': sessionId,
+          'materialId': materialId,
+        };
+      }
+
+      debugPrint('⚠️ Unknown path: ${uri.path}');
+      return null;
+    } catch (e) {
+      debugPrint('❌ Failed to parse link: $e');
+      return null;
+    }
+  }
+
+  /// Deep Link URL 생성
+  String generateMaterialLink(String sessionId, String materialId) {
+    return 'pentalk://material/$sessionId/$materialId';
+  }
+
+  /// Deep Link를 웹 링크로도 변환 (선택사항)
+  String generateWebLink(String sessionId, String materialId) {
+    return 'https://pentalk.app/material/$sessionId/$materialId';
+  }
+}

--- a/pentalk_front/lib/services/local_db_service.dart
+++ b/pentalk_front/lib/services/local_db_service.dart
@@ -1,0 +1,279 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:path/path.dart';
+import 'package:flutter/foundation.dart';
+import '../models/personal_stroke.dart';
+
+/// ===============================
+/// 로컬 DB 서비스 (개인 필기 저장용)
+/// SQLite 사용
+/// ===============================
+class LocalDbService {
+  static final LocalDbService _instance = LocalDbService._internal();
+  static Database? _database;
+
+  factory LocalDbService() => _instance;
+
+  LocalDbService._internal();
+
+  /// 데이터베이스 초기화
+  Future<Database> get database async {
+    if (_database != null) return _database!;
+
+    _database = await _initDatabase();
+    return _database!;
+  }
+
+  /// DB 파일 생성 및 테이블 생성
+  Future<Database> _initDatabase() async {
+    final dbPath = await getDatabasesPath();
+    final path = join(dbPath, 'personal_strokes.db');
+
+    debugPrint('📂 Opening database at: $path');
+
+    return await openDatabase(
+      path,
+      version: 1,
+      onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
+    );
+  }
+
+  /// 테이블 생성
+  Future<void> _onCreate(Database db, int version) async {
+    debugPrint('🔨 Creating personal_strokes table...');
+
+    await db.execute('''
+      CREATE TABLE personal_strokes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        page_id TEXT NOT NULL,
+        stroke_id INTEGER NOT NULL,
+        color INTEGER NOT NULL,
+        width REAL NOT NULL,
+        points_json TEXT NOT NULL,
+        refined_points_json TEXT,
+        timestamp TEXT NOT NULL,
+        UNIQUE(page_id, stroke_id)
+      )
+    ''');
+
+    // 페이지별 조회 최적화를 위한 인덱스
+    await db.execute('''
+      CREATE INDEX idx_page_id ON personal_strokes(page_id)
+    ''');
+
+    // 시간순 정렬을 위한 인덱스
+    await db.execute('''
+      CREATE INDEX idx_timestamp ON personal_strokes(timestamp)
+    ''');
+
+    debugPrint('✅ Table created successfully');
+  }
+
+  /// DB 버전 업그레이드 (나중에 필요시)
+  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    debugPrint('⬆️ Upgrading database from v$oldVersion to v$newVersion');
+
+    // 예: 버전 2에서 새 컬럼 추가
+    // if (oldVersion < 2) {
+    //   await db.execute('ALTER TABLE personal_strokes ADD COLUMN new_field TEXT');
+    // }
+  }
+
+  /// ===============================
+  /// CRUD 작업
+  /// ===============================
+
+  /// 1. 개인 필기 저장
+  Future<int> insertStroke(PersonalStroke stroke) async {
+    try {
+      final db = await database;
+      final id = await db.insert(
+        'personal_strokes',
+        stroke.toMap(),
+        conflictAlgorithm: ConflictAlgorithm.replace, // 같은 stroke_id면 덮어쓰기
+      );
+
+      debugPrint('💾 Saved stroke #${stroke.strokeId} to DB (id: $id)');
+      return id;
+    } catch (e) {
+      debugPrint('❌ Failed to save stroke: $e');
+      rethrow;
+    }
+  }
+
+  /// 2. 여러 개 한번에 저장 (배치)
+  Future<void> insertStrokeBatch(List<PersonalStroke> strokes) async {
+    if (strokes.isEmpty) return;
+
+    try {
+      final db = await database;
+      final batch = db.batch();
+
+      for (final stroke in strokes) {
+        batch.insert(
+          'personal_strokes',
+          stroke.toMap(),
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+      }
+
+      await batch.commit(noResult: true);
+      debugPrint('💾 Saved ${strokes.length} strokes in batch');
+    } catch (e) {
+      debugPrint('❌ Failed to save batch: $e');
+      rethrow;
+    }
+  }
+
+  /// 3. 특정 페이지의 모든 필기 가져오기
+  Future<List<PersonalStroke>> getStrokesByPageId(String pageId) async {
+    try {
+      final db = await database;
+      final List<Map<String, dynamic>> maps = await db.query(
+        'personal_strokes',
+        where: 'page_id = ?',
+        whereArgs: [pageId],
+        orderBy: 'timestamp ASC', // 시간순 정렬
+      );
+
+      final strokes = maps.map((map) => PersonalStroke.fromMap(map)).toList();
+      debugPrint('📖 Loaded ${strokes.length} strokes for page: $pageId');
+
+      return strokes;
+    } catch (e) {
+      debugPrint('❌ Failed to load strokes: $e');
+      return [];
+    }
+  }
+
+  /// 4. 특정 stroke 삭제 (실행 취소용)
+  Future<int> deleteStroke(String pageId, int strokeId) async {
+    try {
+      final db = await database;
+      final count = await db.delete(
+        'personal_strokes',
+        where: 'page_id = ? AND stroke_id = ?',
+        whereArgs: [pageId, strokeId],
+      );
+
+      debugPrint('🗑️ Deleted stroke #$strokeId (rows affected: $count)');
+      return count;
+    } catch (e) {
+      debugPrint('❌ Failed to delete stroke: $e');
+      return 0;
+    }
+  }
+
+  /// 5. 특정 페이지의 모든 필기 삭제
+  Future<int> deleteAllStrokesInPage(String pageId) async {
+    try {
+      final db = await database;
+      final count = await db.delete(
+        'personal_strokes',
+        where: 'page_id = ?',
+        whereArgs: [pageId],
+      );
+
+      debugPrint('🗑️ Deleted all strokes in page: $pageId (count: $count)');
+      return count;
+    } catch (e) {
+      debugPrint('❌ Failed to delete all strokes: $e');
+      return 0;
+    }
+  }
+
+  /// 6. 전체 데이터 삭제 (앱 초기화용)
+  Future<void> deleteAllStrokes() async {
+    try {
+      final db = await database;
+      await db.delete('personal_strokes');
+      debugPrint('🗑️ Deleted all personal strokes');
+    } catch (e) {
+      debugPrint('❌ Failed to delete all: $e');
+    }
+  }
+
+  /// 7. 특정 시간 이전 필기 삭제 (정리용)
+  Future<int> deleteStrokesOlderThan(DateTime date) async {
+    try {
+      final db = await database;
+      final count = await db.delete(
+        'personal_strokes',
+        where: 'timestamp < ?',
+        whereArgs: [date.toIso8601String()],
+      );
+
+      debugPrint('🗑️ Deleted $count old strokes before $date');
+      return count;
+    } catch (e) {
+      debugPrint('❌ Failed to delete old strokes: $e');
+      return 0;
+    }
+  }
+
+  /// 8. 전체 페이지 목록 가져오기
+  Future<List<String>> getAllPageIds() async {
+    try {
+      final db = await database;
+      final List<Map<String, dynamic>> maps = await db.rawQuery(
+        'SELECT DISTINCT page_id FROM personal_strokes ORDER BY page_id',
+      );
+
+      return maps.map((m) => m['page_id'] as String).toList();
+    } catch (e) {
+      debugPrint('❌ Failed to get page list: $e');
+      return [];
+    }
+  }
+
+  /// 9. 통계: 총 필기 개수
+  Future<int> getTotalStrokeCount() async {
+    try {
+      final db = await database;
+      final result = await db.rawQuery('SELECT COUNT(*) as count FROM personal_strokes');
+      return Sqflite.firstIntValue(result) ?? 0;
+    } catch (e) {
+      debugPrint('❌ Failed to get count: $e');
+      return 0;
+    }
+  }
+
+  /// 10. 통계: 페이지별 필기 개수
+  Future<Map<String, int>> getStrokeCountByPage() async {
+    try {
+      final db = await database;
+      final List<Map<String, dynamic>> maps = await db.rawQuery(
+        'SELECT page_id, COUNT(*) as count FROM personal_strokes GROUP BY page_id',
+      );
+
+      return Map.fromEntries(
+        maps.map((m) => MapEntry(m['page_id'] as String, m['count'] as int)),
+      );
+    } catch (e) {
+      debugPrint('❌ Failed to get stats: $e');
+      return {};
+    }
+  }
+
+  /// ===============================
+  /// 유틸리티
+  /// ===============================
+
+  /// DB 닫기
+  Future<void> close() async {
+    final db = await database;
+    await db.close();
+    _database = null;
+    debugPrint('📪 Database closed');
+  }
+
+  /// DB 완전 삭제 (개발/테스트용)
+  Future<void> deleteDatabase() async {
+    final dbPath = await getDatabasesPath();
+    final path = join(dbPath, 'personal_strokes.db');
+
+    await databaseFactory.deleteDatabase(path);
+    _database = null;
+    debugPrint('💥 Database deleted: $path');
+  }
+}

--- a/pentalk_front/lib/services/socket_service.dart
+++ b/pentalk_front/lib/services/socket_service.dart
@@ -233,7 +233,7 @@ class SocketService {
       return;
     }
 
-    _socket!.emit('clear_all', {
+    _socket!.emit('draw:clear', {
       'roomId': _currentRoomId,
       'senderId': senderId,
       'timestamp': DateTime.now().millisecondsSinceEpoch,

--- a/pentalk_front/lib/services/socket_service.dart
+++ b/pentalk_front/lib/services/socket_service.dart
@@ -146,9 +146,12 @@ class SocketService {
 
     // 동기화 데이터 수신 (재접속 시)
     _socket!.on('sync_state', (data) {
-      debugPrint('📥 Received sync_state');
-      if (data is List) {
-        onSyncState?.call(data);
+      debugPrint('📥 Received sync_state: $data');
+      // 1. 데이터가 Map 형태이고, 'strokes'라는 키를 가지고 있는지 확인
+      if (data is Map && data.containsKey('strokes')) {
+        // 2. 배열만  뽑아서 전달
+        final List<dynamic> strokesList = data['strokes'];
+        onSyncState?.call(strokesList);
       }
     });
 

--- a/pentalk_front/lib/services/socket_service.dart
+++ b/pentalk_front/lib/services/socket_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:socket_io_client/socket_io_client.dart' as IO;
 import '../models/drawing_models.dart';
+import '../models/participant_model.dart';
 
 /// ===============================
 /// Socket.IO 서비스
@@ -22,6 +23,11 @@ class SocketService {
   Function(List<dynamic>)? onSyncState; // 동기화 데이터 수신
   Function(Map<String, dynamic>)? onSessionEnded; // 세션 종료 알림
 
+  // ✅ Presence 콜백
+  Function(List<Participant>)? onPresenceState;
+  Function(Participant)? onPresenceJoin;
+  Function(String userId, String role)? onPresenceLeave;
+
   bool get isConnected => _socket?.connected ?? false;
   String? get currentRoomId => _currentRoomId;
   String? get currentUserId => _currentUserId;
@@ -34,25 +40,25 @@ class SocketService {
     required String userId,
     required String roomId,
     bool isTeacher = false,
-    String? jwtToken, // JWT 토큰 추가
+    String? jwtToken,
   }) async {
     try {
       _currentUserId = userId;
       _currentRoomId = roomId;
-      _isTeacher = isTeacher; // 재접속 시 사용
+      _isTeacher = isTeacher;
 
       debugPrint('Connecting to Socket.IO: $serverUrl');
       debugPrint('User ID: $userId, Room ID: $roomId, isTeacher: $isTeacher');
 
       // Socket.IO 옵션 설정
       final optionsBuilder = IO.OptionBuilder()
-          .setTransports(['websocket']) // WebSocket 우선 사용
-          .disableAutoConnect(); // 수동 연결
+          .setTransports(['websocket'])
+          .disableAutoConnect();
 
       // JWT 토큰이 있으면 인증 설정
       if (jwtToken != null && jwtToken.isNotEmpty) {
         optionsBuilder.setAuth({
-          'token': jwtToken, // 명세서 방식: JWT 인증
+          'token': jwtToken,
         });
         debugPrint('🔐 JWT token added to auth');
       }
@@ -65,7 +71,7 @@ class SocketService {
       // 연결 시작
       _socket!.connect();
 
-      // 연결 대기 (최대 5초)
+      // 연결 대기
       await Future.delayed(const Duration(milliseconds: 500));
 
       if (_socket!.connected) {
@@ -88,7 +94,7 @@ class SocketService {
     _socket!.on('connect', (_) {
       debugPrint('✅ Socket.IO connected: ${_socket!.id}');
 
-      // 재접속 시 자동으로 방 다시 참여 (명세서 요구사항)
+      // 재접속 시 자동으로 방 다시 참여
       if (_currentRoomId != null && _currentUserId != null) {
         final isTeacher = _isTeacher ?? false;
         _joinRoom(_currentRoomId!, _currentUserId!, isTeacher);
@@ -166,6 +172,82 @@ class SocketService {
       debugPrint('❌ Socket error: $error');
       onError?.call(error);
     });
+
+    // ========================================
+    // ✅ Presence 이벤트 리스너 (여기 추가!)
+    // ========================================
+
+    // PRESENCE_STATE: 전체 참여자 목록
+    _socket!.on('presence:state', (data) {
+      debugPrint('📥 PRESENCE_STATE received: $data');
+
+      if (data is! Map) return;
+
+      final usersList = data['users'];
+      if (usersList is! List) return;
+
+      final participants = usersList
+          .where((u) => u is Map)
+          .map((u) => Participant.fromJson(Map<String, dynamic>.from(u)))
+          .toList();
+
+      onPresenceState?.call(participants);
+    });
+
+    // PRESENCE_JOIN: 새 참여자 입장
+    _socket!.on('presence:join', (data) {
+      debugPrint('📥 PRESENCE_JOIN received: $data');
+
+      if (data is! Map) return;
+
+      try {
+        final participant = Participant.fromJson(Map<String, dynamic>.from(data));
+        onPresenceJoin?.call(participant);
+      } catch (e) {
+        debugPrint('❌ Failed to parse PRESENCE_JOIN: $e');
+      }
+    });
+
+    // PRESENCE_LEAVE: 참여자 퇴장
+    _socket!.on('presence:leave', (data) {
+      debugPrint('📥 PRESENCE_LEAVE received: $data');
+
+      if (data is! Map) return;
+
+      final userId = data['userId'] as String?;
+      final role = data['role'] as String?;
+
+      if (userId != null && role != null) {
+        onPresenceLeave?.call(userId, role);
+      }
+    });
+  }
+
+  /// ===============================
+  /// ✅ Presence 리스너 설정 (신규 메서드!)
+  /// DrawingProvider에서 호출용
+  /// ===============================
+  void setupPresenceListeners() {
+    // 이미 _setupEventListeners()에서 등록되어 있음
+    // 이 메서드는 명시적 호출용 (실제 리스너는 위에서 이미 설정됨)
+    debugPrint('🔔 Presence listeners are ready');
+  }
+
+  /// ===============================
+  /// ✅ Presence 리스너 제거 (신규 메서드!)
+  /// ===============================
+  void removePresenceListeners() {
+    if (_socket == null) return;
+
+    _socket!.off('presence:state');
+    _socket!.off('presence:join');
+    _socket!.off('presence:leave');
+
+    onPresenceState = null;
+    onPresenceJoin = null;
+    onPresenceLeave = null;
+
+    debugPrint('🔕 Presence listeners removed');
   }
 
   /// ===============================
@@ -177,7 +259,6 @@ class SocketService {
       return;
     }
 
-    // 명세서 방식: role 사용, timestamp 제거
     final role = isTeacher ? 'teacher' : 'student';
 
     _socket!.emit('join_room', {
@@ -207,7 +288,6 @@ class SocketService {
 
     _socket!.emit('draw_event', data);
 
-    // draw_move는 너무 많이 로그되므로 제외
     if (event.eventType != DrawEventType.drawMove) {
       debugPrint('📤 Sent draw_event: ${event.eventType.code}');
     }
@@ -273,11 +353,16 @@ class SocketService {
   /// ===============================
   void disconnect() {
     leaveRoom();
+
+    // ✅ Presence 리스너 정리 추가!
+    removePresenceListeners();
+
     _socket?.disconnect();
     _socket?.dispose();
     _socket = null;
     _currentRoomId = null;
     _currentUserId = null;
+
     debugPrint('🔌 Socket.IO disconnected and disposed');
   }
 

--- a/pentalk_front/lib/services/socket_service.dart
+++ b/pentalk_front/lib/services/socket_service.dart
@@ -20,6 +20,7 @@ class SocketService {
   Function()? onDisconnected;
   Function(dynamic)? onError;
   Function(List<dynamic>)? onSyncState; // 동기화 데이터 수신
+  Function(Map<String, dynamic>)? onSessionEnded; // 세션 종료 알림
 
   bool get isConnected => _socket?.connected ?? false;
   String? get currentRoomId => _currentRoomId;
@@ -146,12 +147,17 @@ class SocketService {
 
     // 동기화 데이터 수신 (재접속 시)
     _socket!.on('sync_state', (data) {
-      debugPrint('📥 Received sync_state: $data');
-      // 1. 데이터가 Map 형태이고, 'strokes'라는 키를 가지고 있는지 확인
-      if (data is Map && data.containsKey('strokes')) {
-        // 2. 배열만  뽑아서 전달
-        final List<dynamic> strokesList = data['strokes'];
-        onSyncState?.call(strokesList);
+      debugPrint('📥 Received sync_state');
+      if (data is List) {
+        onSyncState?.call(data);
+      }
+    });
+
+    // 세션 종료 알림
+    _socket!.on('session:ended', (data) {
+      debugPrint('📥 Received session:ended: $data');
+      if (data is Map) {
+        onSessionEnded?.call(Map<String, dynamic>.from(data));
       }
     });
 
@@ -236,7 +242,7 @@ class SocketService {
       return;
     }
 
-    _socket!.emit('draw:clear', {
+    _socket!.emit('clear_all', {
       'roomId': _currentRoomId,
       'senderId': senderId,
       'timestamp': DateTime.now().millisecondsSinceEpoch,

--- a/pentalk_front/lib/services/upload_queue_service.dart
+++ b/pentalk_front/lib/services/upload_queue_service.dart
@@ -1,0 +1,244 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:path/path.dart';
+import 'package:flutter/foundation.dart';
+import 'dart:convert';
+import '../models/drawing_models.dart';
+
+/// ===============================
+/// 업로드 Queue 관리 서비스
+/// 실패한 배치를 저장했다가 재전송
+/// ===============================
+class UploadQueueService {
+  static Database? _database;
+
+  /// 데이터베이스 초기화
+  static Future<Database> get database async {
+    if (_database != null) return _database!;
+    _database = await _initDatabase();
+    return _database!;
+  }
+
+  static Future<Database> _initDatabase() async {
+    final dbPath = await getDatabasesPath();
+    final path = join(dbPath, 'upload_queue.db');
+
+    return await openDatabase(
+      path,
+      version: 1,
+      onCreate: (db, version) async {
+        await db.execute('''
+          CREATE TABLE pending_uploads (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            strokes_json TEXT NOT NULL,
+            retry_count INTEGER DEFAULT 0,
+            created_at INTEGER NOT NULL,
+            last_attempt_at INTEGER
+          )
+        ''');
+
+        // 인덱스
+        await db.execute('''
+          CREATE INDEX idx_session_id ON pending_uploads(session_id)
+        ''');
+
+        await db.execute('''
+          CREATE INDEX idx_created_at ON pending_uploads(created_at)
+        ''');
+
+        debugPrint('✅ Upload queue database created');
+      },
+    );
+  }
+
+  /// ===============================
+  /// Queue에 배치 추가
+  /// ===============================
+  static Future<int> addToQueue({
+    required String sessionId,
+    required List<Stroke> strokes,
+  }) async {
+    final db = await database;
+
+    // Stroke → JSON
+    final strokesJson = strokes.map((s) => {
+      'sId': s.id,
+      'pts': s.points.map((p) => {'x': p.x, 'y': p.y}).toList(),
+      'c': s.color,
+      'w': s.width,
+    }).toList();
+
+    final id = await db.insert('pending_uploads', {
+      'session_id': sessionId,
+      'strokes_json': jsonEncode(strokesJson),
+      'retry_count': 0,
+      'created_at': DateTime.now().millisecondsSinceEpoch,
+    });
+
+    debugPrint('📥 Added to queue: $id (${strokes.length} strokes)');
+    return id;
+  }
+
+  /// ===============================
+  /// Queue에서 대기 중인 배치 가져오기
+  /// ===============================
+  static Future<List<QueuedBatch>> getPendingBatches() async {
+    final db = await database;
+
+    final results = await db.query(
+      'pending_uploads',
+      orderBy: 'created_at ASC',
+    );
+
+    return results.map((row) {
+      final strokesJson = jsonDecode(row['strokes_json'] as String) as List;
+
+      final strokes = strokesJson.map((json) {
+        final points = (json['pts'] as List).map((p) =>
+            DrawPoint(p['x'], p['y'])
+        ).toList();
+
+        return Stroke(
+          id: json['sId'],
+          points: points,
+          color: json['c'],
+          width: json['w'],
+        );
+      }).toList();
+
+      return QueuedBatch(
+        id: row['id'] as int,
+        sessionId: row['session_id'] as String,
+        strokes: strokes,
+        retryCount: row['retry_count'] as int,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(row['created_at'] as int),
+      );
+    }).toList();
+  }
+
+  /// ===============================
+  /// Queue에서 배치 삭제 (전송 성공 시)
+  /// ===============================
+  static Future<void> removeFromQueue(int id) async {
+    final db = await database;
+
+    await db.delete(
+      'pending_uploads',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+
+    debugPrint('✅ Removed from queue: $id');
+  }
+
+  /// ===============================
+  /// 재시도 횟수 증가
+  /// ===============================
+  static Future<void> incrementRetryCount(int id) async {
+    final db = await database;
+
+    await db.update(
+      'pending_uploads',
+      {
+        'retry_count': (await db.query(
+          'pending_uploads',
+          columns: ['retry_count'],
+          where: 'id = ?',
+          whereArgs: [id],
+        )).first['retry_count'] as int + 1,
+        'last_attempt_at': DateTime.now().millisecondsSinceEpoch,
+      },
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+
+    debugPrint('🔄 Incremented retry count for: $id');
+  }
+
+  /// ===============================
+  /// 재시도 횟수 초과한 배치 삭제
+  /// ===============================
+  static Future<int> removeFailedBatches({int maxRetries = 3}) async {
+    final db = await database;
+
+    final count = await db.delete(
+      'pending_uploads',
+      where: 'retry_count >= ?',
+      whereArgs: [maxRetries],
+    );
+
+    if (count > 0) {
+      debugPrint('🗑️ Removed $count failed batches (max retries exceeded)');
+    }
+
+    return count;
+  }
+
+  /// ===============================
+  /// Queue 통계
+  /// ===============================
+  static Future<QueueStats> getStats() async {
+    final db = await database;
+
+    final result = await db.rawQuery('''
+      SELECT 
+        COUNT(*) as total,
+        SUM(CASE WHEN retry_count = 0 THEN 1 ELSE 0 END) as pending,
+        SUM(CASE WHEN retry_count > 0 THEN 1 ELSE 0 END) as retrying
+      FROM pending_uploads
+    ''');
+
+    final row = result.first;
+    return QueueStats(
+      total: row['total'] as int,
+      pending: row['pending'] as int,
+      retrying: row['retrying'] as int,
+    );
+  }
+
+  /// ===============================
+  /// Queue 전체 삭제 (테스트용)
+  /// ===============================
+  static Future<void> clearAll() async {
+    final db = await database;
+    await db.delete('pending_uploads');
+    debugPrint('🗑️ Cleared all pending uploads');
+  }
+}
+
+/// ===============================
+/// Queue에 저장된 배치
+/// ===============================
+class QueuedBatch {
+  final int id;
+  final String sessionId;
+  final List<Stroke> strokes;
+  final int retryCount;
+  final DateTime createdAt;
+
+  QueuedBatch({
+    required this.id,
+    required this.sessionId,
+    required this.strokes,
+    required this.retryCount,
+    required this.createdAt,
+  });
+}
+
+/// ===============================
+/// Queue 통계
+/// ===============================
+class QueueStats {
+  final int total;
+  final int pending;
+  final int retrying;
+
+  QueueStats({
+    required this.total,
+    required this.pending,
+    required this.retrying,
+  });
+
+  @override
+  String toString() => 'Total: $total, Pending: $pending, Retrying: $retrying';
+}

--- a/pentalk_front/lib/services/upload_queue_service.dart
+++ b/pentalk_front/lib/services/upload_queue_service.dart
@@ -1,6 +1,7 @@
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';  // Color 사용
 import 'dart:convert';
 import '../models/drawing_models.dart';
 
@@ -62,9 +63,9 @@ class UploadQueueService {
 
     // Stroke → JSON
     final strokesJson = strokes.map((s) => {
-      'sId': s.id,
+      'sId': s.strokeId,  // id → strokeId
       'pts': s.points.map((p) => {'x': p.x, 'y': p.y}).toList(),
-      'c': s.color,
+      'c': '#${s.color.value.toRadixString(16).padLeft(8, '0').substring(2)}',
       'w': s.width,
     }).toList();
 
@@ -95,14 +96,22 @@ class UploadQueueService {
 
       final strokes = strokesJson.map((json) {
         final points = (json['pts'] as List).map((p) =>
-            DrawPoint(p['x'], p['y'])
+            DrawPoint(
+              x: (p['x'] as num).toDouble(),
+              y: (p['y'] as num).toDouble(),
+            )
         ).toList();
 
+        // 색상 파싱
+        final colorString = json['c'] as String;
+        final colorInt = int.parse(colorString.replaceFirst('#', ''), radix: 16);
+        final color = Color(0xFF000000 | colorInt);
+
         return Stroke(
-          id: json['sId'],
+          strokeId: json['sId'] as int,
           points: points,
-          color: json['c'],
-          width: json['w'],
+          color: color,
+          width: (json['w'] as num).toDouble(),
         );
       }).toList();
 

--- a/pentalk_front/lib/services/upload_queue_service.dart
+++ b/pentalk_front/lib/services/upload_queue_service.dart
@@ -149,12 +149,12 @@ class UploadQueueService {
     await db.update(
       'pending_uploads',
       {
-        'retry_count': (await db.query(
+        'retry_count': ((await db.query(
           'pending_uploads',
           columns: ['retry_count'],
           where: 'id = ?',
           whereArgs: [id],
-        )).first['retry_count'] as int + 1,
+        )).first['retry_count'] as int) + 1,
         'last_attempt_at': DateTime.now().millisecondsSinceEpoch,
       },
       where: 'id = ?',

--- a/pentalk_front/lib/utils/coordinate_scaler.dart
+++ b/pentalk_front/lib/utils/coordinate_scaler.dart
@@ -1,0 +1,135 @@
+
+import 'package:flutter/material.dart';
+import '../models/drawing_models.dart';
+
+/// ===============================
+/// 좌표 스케일러
+/// PDF/배경 이미지 영역 기준 좌표 변환
+/// ===============================
+class CoordinateScaler {
+  final Size canvasSize; // 전체 캔버스 크기
+  final Size? contentSize; // PDF/이미지의 실제 크기 (선택)
+  final BoxFit fit; // 이미지 fit 방식
+
+  // 계산된 콘텐츠 렌더링 영역
+  late final Rect _contentRect;
+
+  CoordinateScaler({
+    required this.canvasSize,
+    this.contentSize,
+    this.fit = BoxFit.contain,
+  }) {
+    _contentRect = _calculateContentRect();
+  }
+
+  /// ===============================
+  /// PDF/이미지가 실제로 렌더링되는 영역 계산
+  /// ===============================
+  Rect _calculateContentRect() {
+    // 배경 이미지가 없으면 전체 화면 사용
+    if (contentSize == null) {
+      return Rect.fromLTWH(0, 0, canvasSize.width, canvasSize.height);
+    }
+
+    final imageAspect = contentSize!.width / contentSize!.height;
+    final canvasAspect = canvasSize.width / canvasSize.height;
+
+    double renderWidth;
+    double renderHeight;
+    double offsetX = 0;
+    double offsetY = 0;
+
+    switch (fit) {
+      case BoxFit.contain:
+      // 이미지가 캔버스에 완전히 들어가도록 (여백 생김)
+        if (imageAspect > canvasAspect) {
+          // 이미지가 더 넓음 → 가로 꽉 채움
+          renderWidth = canvasSize.width;
+          renderHeight = canvasSize.width / imageAspect;
+          offsetY = (canvasSize.height - renderHeight) / 2;
+        } else {
+          // 이미지가 더 높음 → 세로 꽉 채움
+          renderHeight = canvasSize.height;
+          renderWidth = canvasSize.height * imageAspect;
+          offsetX = (canvasSize.width - renderWidth) / 2;
+        }
+        break;
+
+      case BoxFit.cover:
+      // 이미지가 캔버스를 완전히 덮도록 (잘림)
+        if (imageAspect > canvasAspect) {
+          renderHeight = canvasSize.height;
+          renderWidth = canvasSize.height * imageAspect;
+          offsetX = (canvasSize.width - renderWidth) / 2;
+        } else {
+          renderWidth = canvasSize.width;
+          renderHeight = canvasSize.width / imageAspect;
+          offsetY = (canvasSize.height - renderHeight) / 2;
+        }
+        break;
+
+      case BoxFit.fill:
+      // 이미지를 캔버스에 맞춰 늘림 (비율 무시)
+        renderWidth = canvasSize.width;
+        renderHeight = canvasSize.height;
+        break;
+
+      default:
+      // 기본: contain
+        renderWidth = canvasSize.width;
+        renderHeight = canvasSize.height;
+    }
+
+    return Rect.fromLTWH(offsetX, offsetY, renderWidth, renderHeight);
+  }
+
+  /// ===============================
+  /// 정규화 좌표 (0.0~1.0) → 픽셀 좌표
+  /// ===============================
+  Offset normalizedToPixel(DrawPoint point) {
+    return Offset(
+      _contentRect.left + (point.x * _contentRect.width),
+      _contentRect.top + (point.y * _contentRect.height),
+    );
+  }
+
+  /// ===============================
+  /// 픽셀 좌표 → 정규화 좌표 (0.0~1.0)
+  /// ===============================
+  DrawPoint pixelToNormalized(Offset pixel) {
+    // 콘텐츠 영역 밖이면 clamp
+    final relativeX = (pixel.dx - _contentRect.left) / _contentRect.width;
+    final relativeY = (pixel.dy - _contentRect.top) / _contentRect.height;
+
+    return DrawPoint(
+      x: relativeX.clamp(0.0, 1.0),
+      y: relativeY.clamp(0.0, 1.0),
+    );
+  }
+
+  /// ===============================
+  /// 터치가 콘텐츠 영역 안인지 확인
+  /// ===============================
+  bool isInContentArea(Offset pixel) {
+    return _contentRect.contains(pixel);
+  }
+
+  /// ===============================
+  /// 콘텐츠 렌더링 영역 정보
+  /// ===============================
+  Rect get contentRect => _contentRect;
+  Size get contentRenderSize => _contentRect.size;
+
+  /// ===============================
+  /// 디버그 정보
+  /// ===============================
+  @override
+  String toString() {
+    return 'CoordinateScaler(\n'
+        '  canvasSize: $canvasSize\n'
+        '  contentSize: $contentSize\n'
+        '  contentRect: $_contentRect\n'
+        '  fit: $fit\n'
+        ')';
+  }
+}

--- a/pentalk_front/lib/utils/route_guard.dart
+++ b/pentalk_front/lib/utils/route_guard.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import '../services/auth_service.dart';
+import '../widgets/access_denied_dialog.dart';
+
+
+/// 라우팅 가드
+/// 인증 상태 확인 후 화면 이동
+
+class RouteGuard {
+  /// 세션 입장 전 인증 확인
+  ///
+  /// 사용 예:
+  /// ```dart
+  /// final canJoin = await RouteGuard.canJoinSession(context);
+  /// if (canJoin) {
+  ///   Navigator.push(...);
+  /// }
+  /// ```
+  static Future<bool> canJoinSession(BuildContext context) async {
+    // 1. 토큰 확인
+    final token = await AuthService.getToken();
+
+    if (token == null || token.isEmpty) {
+      // 토큰 없음 → 로그인 필요 팝업
+      if (context.mounted) {
+        await AccessDeniedDialog.showLoginRequired(context);
+      }
+      return false;
+    }
+
+    // 2. 사용자 정보 확인
+    final userId = await AuthService.getUserId();
+    final role = await AuthService.getRole();
+
+    if (userId == null || role == null) {
+      // 정보 불완전 → 로그인 필요
+      if (context.mounted) {
+        await AccessDeniedDialog.showLoginRequired(context);
+      }
+      return false;
+    }
+
+    // 3. role 검증
+    if (role != 'teacher' && role != 'student') {
+      // 잘못된 role
+      if (context.mounted) {
+        await AccessDeniedDialog.showPermissionDenied(context);
+      }
+      return false;
+    }
+
+    // ✅ 모든 검증 통과
+    return true;
+  }
+
+  /// 교사 전용 기능 접근 확인
+  static Future<bool> requireTeacher(BuildContext context) async {
+    // 1. 기본 인증 확인
+    final isLoggedIn = await canJoinSession(context);
+    if (!isLoggedIn) return false;
+
+    // 2. 교사 권한 확인
+    final role = await AuthService.getRole();
+
+    if (role != 'teacher') {
+      if (context.mounted) {
+        await AccessDeniedDialog.showPermissionDenied(context);
+      }
+      return false;
+    }
+
+    return true;
+  }
+
+  /// 로그인 상태 확인 (팝업 없음)
+  static Future<bool> isAuthenticated() async {
+    final token = await AuthService.getToken();
+    final userId = await AuthService.getUserId();
+    final role = await AuthService.getRole();
+
+    return token != null &&
+        token.isNotEmpty &&
+        userId != null &&
+        role != null;
+  }
+
+  /// 초기 라우트 결정
+  ///
+  /// main.dart에서 사용:
+  /// ```dart
+  /// home: await RouteGuard.getInitialRoute(),
+  /// ```
+  static Future<String> getInitialRoute() async {
+    final isAuth = await isAuthenticated();
+    return isAuth ? '/home' : '/login';
+  }
+}

--- a/pentalk_front/lib/widgets/access_denied_dialog.dart
+++ b/pentalk_front/lib/widgets/access_denied_dialog.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+
+/// ===============================
+/// 입장 불가 팝업
+/// 인증 실패 시 표시
+/// ===============================
+class AccessDeniedDialog {
+  /// 인증 실패 팝업 (로그인 필요)
+  static Future<void> showLoginRequired(BuildContext context) async {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: Row(
+          children: const [
+            Icon(Icons.lock, color: Colors.red),
+            SizedBox(width: 12),
+            Text('로그인 필요'),
+          ],
+        ),
+        content: const Text(
+          '수업에 참여하려면 먼저 로그인해주세요.',
+          style: TextStyle(fontSize: 15),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context); // 팝업 닫기
+              Navigator.pushReplacementNamed(context, '/login'); // 로그인 화면으로
+            },
+            child: const Text(
+              '로그인하기',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 권한 없음 팝업 (role 불일치)
+  static Future<void> showPermissionDenied(BuildContext context) async {
+    return showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: Row(
+          children: const [
+            Icon(Icons.block, color: Colors.orange),
+            SizedBox(width: 12),
+            Text('권한 없음'),
+          ],
+        ),
+        content: const Text(
+          '이 기능에 접근할 권한이 없습니다.\n교사 계정으로 로그인해주세요.',
+          style: TextStyle(fontSize: 15),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 세션 접근 불가 (classId 불일치 등)
+  static Future<void> showSessionAccessDenied(
+      BuildContext context, {
+        String? reason,
+      }) async {
+    return showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: Row(
+          children: const [
+            Icon(Icons.warning, color: Colors.red),
+            SizedBox(width: 12),
+            Text('입장 불가'),
+          ],
+        ),
+        content: Text(
+          reason ?? '이 세션에 접근할 수 없습니다.\n권한을 확인해주세요.',
+          style: const TextStyle(fontSize: 15),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 네트워크 오류
+  static Future<void> showNetworkError(BuildContext context) async {
+    return showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: Row(
+          children: const [
+            Icon(Icons.wifi_off, color: Colors.grey),
+            SizedBox(width: 12),
+            Text('네트워크 오류'),
+          ],
+        ),
+        content: const Text(
+          '서버에 연결할 수 없습니다.\n네트워크 연결을 확인해주세요.',
+          style: TextStyle(fontSize: 15),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 토큰 만료
+  static Future<void> showTokenExpired(BuildContext context) async {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: Row(
+          children: const [
+            Icon(Icons.timer_off, color: Colors.orange),
+            SizedBox(width: 12),
+            Text('세션 만료'),
+          ],
+        ),
+        content: const Text(
+          '로그인 세션이 만료되었습니다.\n다시 로그인해주세요.',
+          style: TextStyle(fontSize: 15),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              Navigator.pushReplacementNamed(context, '/login');
+            },
+            child: const Text(
+              '다시 로그인',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pentalk_front/lib/widgets/drawing_canvas_widget.dart
+++ b/pentalk_front/lib/widgets/drawing_canvas_widget.dart
@@ -1,12 +1,17 @@
-
+import 'dart:async';
+import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/drawing_provider.dart';
+import '../providers/personal_drawing_provider.dart';
 import '../models/drawing_models.dart';
+import '../utils/coordinate_scaler.dart';
 import 'drawing_painter.dart';
 
 /// ===============================
-/// 판서 캔버스 위젯 (레이어 분리 + 최적화)
+/// 판서 캔버스 위젯 (레이어 분리 + 최적화 + InteractiveViewer)
+/// CoordinateScaler 통합으로 정확한 좌표 변환
+/// InteractiveViewer로 줌/팬 지원
 /// ===============================
 class DrawingCanvasWidget extends StatefulWidget {
   final bool isTeacher;
@@ -24,87 +29,322 @@ class _DrawingCanvasWidgetState extends State<DrawingCanvasWidget> {
   int? _currentStrokeId;
   final List<DrawPoint> _currentPoints = [];
 
+  // 배경 이미지 크기 (로드되면 설정됨)
+  Size? _backgroundImageSize;
+
+  // InteractiveViewer 컨트롤러
+  final TransformationController _transformationController =
+  TransformationController();
+
+  // 현재 줌 레벨
+  double _currentScale = 1.0;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // 줌 변경 감지
+    _transformationController.addListener(_onTransformChanged);
+  }
+
+  @override
+  void dispose() {
+    _transformationController.removeListener(_onTransformChanged);
+    _transformationController.dispose();
+    super.dispose();
+  }
+
+  void _onTransformChanged() {
+    final matrix = _transformationController.value;
+    final newScale = matrix.getMaxScaleOnAxis();
+
+    if ((_currentScale - newScale).abs() > 0.01) {
+      setState(() {
+        _currentScale = newScale;
+      });
+
+      debugPrint('Zoom level: ${_currentScale.toStringAsFixed(2)}x');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
         final canvasSize = Size(constraints.maxWidth, constraints.maxHeight);
 
-        return Stack(
-          children: [
-            // ====================================
-            // 레이어 1: 배경 (문서/이미지/PDF)
-            // RepaintBoundary로 분리 → 배경은 한 번만 렌더링
-            // ====================================
-            RepaintBoundary(
-              child: _BackgroundLayer(canvasSize: canvasSize),
-            ),
+        return Consumer<DrawingProvider>(
+          builder: (context, provider, child) {
+            // 그리기 모드일 때는 InteractiveViewer 비활성화
+            final isDrawingMode = provider.isDrawingMode && widget.isTeacher;
 
-            // ====================================
-            // 레이어 2: 다른 사람들의 판서 (파란색)
-            // RepaintBoundary로 분리
-            // ====================================
-            RepaintBoundary(
-              child: _OthersDrawingLayer(canvasSize: canvasSize),
-            ),
+            return Stack(
+              children: [
+                // ====================================
+                // InteractiveViewer로 전체 감싸기
+                // ====================================
+                InteractiveViewer(
+                  transformationController: _transformationController,
+                  panEnabled: !isDrawingMode, // 그리기 모드에서는 팬 비활성화
+                  scaleEnabled: !isDrawingMode, // 그리기 모드에서는 줌 비활성화
+                  minScale: 0.5,
+                  maxScale: 4.0,
+                  boundaryMargin: const EdgeInsets.all(double.infinity),
+                  child: SizedBox(
+                    width: canvasSize.width,
+                    height: canvasSize.height,
+                    child: Stack(
+                      children: [
+                        // ====================================
+                        // 레이어 1: 배경 (문서/이미지/PDF)
+                        // ====================================
+                        RepaintBoundary(
+                          child: _BackgroundLayer(
+                            canvasSize: canvasSize,
+                            onImageLoaded: (size) {
+                              setState(() {
+                                _backgroundImageSize = size;
+                              });
+                            },
+                          ),
+                        ),
 
-            // ====================================
-            // 레이어 3: 내 판서 (검은색)
-            // RepaintBoundary로 분리
-            // ====================================
-            RepaintBoundary(
-              child: _MyDrawingLayer(canvasSize: canvasSize),
-            ),
+                        // ====================================
+                        // 레이어 2: 다른 사람들의 판서 (파란색)
+                        // ====================================
+                        RepaintBoundary(
+                          child: _OthersDrawingLayer(
+                            canvasSize: canvasSize,
+                            backgroundImageSize: _backgroundImageSize,
+                            scale: _currentScale,
+                          ),
+                        ),
 
-            // ====================================
-            // 레이어 4: 터치 입력 (교사 전용)
-            // ====================================
-            if (widget.isTeacher)
-              _TouchInputLayer(
-                canvasSize: canvasSize,
-                currentStrokeId: _currentStrokeId,
-                currentPoints: _currentPoints,
-                onPanStart: _onPanStart,
-                onPanUpdate: _onPanUpdate,
-                onPanEnd: _onPanEnd,
-              ),
+                        // ====================================
+                        // 레이어 3: 내 판서 (검은색) - 교사 공용 판서
+                        // ====================================
+                        if (widget.isTeacher)
+                          RepaintBoundary(
+                            child: _MyDrawingLayer(
+                              canvasSize: canvasSize,
+                              backgroundImageSize: _backgroundImageSize,
+                              scale: _currentScale,
+                            ),
+                          ),
 
-            // ====================================
-            // 레이어 5: 소켓 연결 상태 표시
-            // ====================================
-            Positioned(
-              top: 8,
-              right: 8,
-              child: _SocketStatusIndicator(),
-            ),
-          ],
+                        // ====================================
+                        // 레이어 3.5: 개인 필기 레이어 (학생 전용)
+                        // ====================================
+                        if (!widget.isTeacher)
+                          RepaintBoundary(
+                            child: _PersonalDrawingLayer(
+                              canvasSize: canvasSize,
+                              backgroundImageSize: _backgroundImageSize,
+                              scale: _currentScale,
+                            ),
+                          ),
+
+                        // ====================================
+                        // 레이어 4: 터치 입력
+                        // ====================================
+                        // 교사: 공용 판서용
+                        if (widget.isTeacher && isDrawingMode)
+                          _TouchInputLayer(
+                            canvasSize: canvasSize,
+                            backgroundImageSize: _backgroundImageSize,
+                            currentStrokeId: _currentStrokeId,
+                            currentPoints: _currentPoints,
+                            transformationController: _transformationController,
+                            onPanStart: _onPanStart,
+                            onPanUpdate: _onPanUpdate,
+                            onPanEnd: _onPanEnd,
+                          ),
+
+                        // 학생: 개인 필기용
+                        if (!widget.isTeacher && isDrawingMode)
+                          _PersonalTouchInputLayer(
+                            canvasSize: canvasSize,
+                            backgroundImageSize: _backgroundImageSize,
+                            currentStrokeId: _currentStrokeId,
+                            currentPoints: _currentPoints,
+                            transformationController: _transformationController,
+                            onPanStart: _onPersonalPanStart,
+                            onPanUpdate: _onPersonalPanUpdate,
+                            onPanEnd: _onPersonalPanEnd,
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                // ====================================
+                // 레이어 5: 소켓 연결 상태 표시
+                // ====================================
+                Positioned(
+                  top: 8,
+                  right: 8,
+                  child: _SocketStatusIndicator(),
+                ),
+
+                // ====================================
+                // 레이어 6: 줌 레벨 표시
+                // ====================================
+                Positioned(
+                  top: 8,
+                  left: 8,
+                  child: _ZoomIndicator(scale: _currentScale),
+                ),
+
+                // ====================================
+                // 레이어 7: 디버그 정보 (개발용)
+                // ====================================
+                if (_backgroundImageSize != null)
+                  Positioned(
+                    bottom: 8,
+                    left: 8,
+                    child: Container(
+                      padding: const EdgeInsets.all(4),
+                      decoration: BoxDecoration(
+                        color: Colors.black54,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: Text(
+                        'Canvas: ${canvasSize.width.toInt()}x${canvasSize.height.toInt()}\n'
+                            'Image: ${_backgroundImageSize!.width.toInt()}x${_backgroundImageSize!.height.toInt()}\n'
+                            'Zoom: ${_currentScale.toStringAsFixed(2)}x',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 10,
+                          fontFamily: 'monospace',
+                        ),
+                      ),
+                    ),
+                  ),
+
+                // ====================================
+                // 레이어 8: 모드 안내 (그리기 모드일 때)
+                // ====================================
+                if (isDrawingMode)
+                  Positioned(
+                    bottom: 60,
+                    left: 0,
+                    right: 0,
+                    child: Center(
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.blue.withOpacity(0.8),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: const Text(
+                          '✏️ 그리기 모드 (줌/이동 비활성화)',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 12,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            );
+          },
         );
       },
     );
   }
 
-  void _onPanStart(DragStartDetails details, Size canvasSize, DrawingProvider provider) {
+  void _onPanStart(DragStartDetails details, CoordinateScaler scaler, DrawingProvider provider) {
+    // InteractiveViewer의 변환을 고려한 실제 로컬 좌표 계산
+    final localPosition = _getTransformedPosition(details.localPosition);
+
+    // 터치가 콘텐츠 영역 안인지 확인
+    if (!scaler.isInContentArea(localPosition)) {
+      return;
+    }
+
     _currentPoints.clear();
 
-    final point = DrawPoint.fromPixelOffset(details.localPosition, canvasSize);
+    final point = scaler.pixelToNormalized(localPosition);
     _currentPoints.add(point);
 
     _currentStrokeId = provider.sendDrawStart(point);
   }
 
-  void _onPanUpdate(DragUpdateDetails details, Size canvasSize, DrawingProvider provider) {
+  void _onPanUpdate(DragUpdateDetails details, CoordinateScaler scaler, DrawingProvider provider) {
     if (_currentStrokeId == null) return;
 
-    final point = DrawPoint.fromPixelOffset(details.localPosition, canvasSize);
+    // InteractiveViewer의 변환을 고려한 실제 로컬 좌표 계산
+    final localPosition = _getTransformedPosition(details.localPosition);
+
+    // 터치가 콘텐츠 영역 안인지 확인
+    if (!scaler.isInContentArea(localPosition)) {
+      return;
+    }
+
+    final point = scaler.pixelToNormalized(localPosition);
     _currentPoints.add(point);
 
     provider.sendDrawMove(_currentStrokeId!, point);
   }
 
-  void _onPanEnd(Size canvasSize, DrawingProvider provider) {
+  void _onPanEnd(CoordinateScaler scaler, DrawingProvider provider) {
     if (_currentStrokeId == null) return;
 
     provider.sendDrawEnd(_currentStrokeId!, _currentPoints);
+
+    _currentStrokeId = null;
+    _currentPoints.clear();
+  }
+
+  /// InteractiveViewer의 변환을 역으로 적용하여 실제 좌표 계산
+  Offset _getTransformedPosition(Offset screenPosition) {
+    final matrix = _transformationController.value.clone()..invert();
+    final transformed = MatrixUtils.transformPoint(matrix, screenPosition);
+    return transformed;
+  }
+
+  /// ===============================
+  /// 개인 필기 터치 이벤트 (학생용)
+  /// ===============================
+  void _onPersonalPanStart(DragStartDetails details, CoordinateScaler scaler, PersonalDrawingProvider provider, Color color, double width) {
+    final localPosition = _getTransformedPosition(details.localPosition);
+
+    if (!scaler.isInContentArea(localPosition)) {
+      return;
+    }
+
+    _currentPoints.clear();
+    final point = scaler.pixelToNormalized(localPosition);
+    _currentPoints.add(point);
+
+    _currentStrokeId = DateTime.now().millisecondsSinceEpoch;
+    provider.startDrawing(_currentStrokeId!, point, color, width);
+  }
+
+  void _onPersonalPanUpdate(DragUpdateDetails details, CoordinateScaler scaler, PersonalDrawingProvider provider) {
+    if (_currentStrokeId == null) return;
+
+    final localPosition = _getTransformedPosition(details.localPosition);
+
+    if (!scaler.isInContentArea(localPosition)) {
+      return;
+    }
+
+    final point = scaler.pixelToNormalized(localPosition);
+    _currentPoints.add(point);
+
+    provider.updateDrawing(_currentStrokeId!, point);
+  }
+
+  void _onPersonalPanEnd(CoordinateScaler scaler, PersonalDrawingProvider provider) {
+    if (_currentStrokeId == null) return;
+
+    provider.endDrawing(_currentStrokeId!, _currentPoints);
 
     _currentStrokeId = null;
     _currentPoints.clear();
@@ -116,8 +356,12 @@ class _DrawingCanvasWidgetState extends State<DrawingCanvasWidget> {
 /// ===============================
 class _BackgroundLayer extends StatelessWidget {
   final Size canvasSize;
+  final Function(Size) onImageLoaded;
 
-  const _BackgroundLayer({required this.canvasSize});
+  const _BackgroundLayer({
+    required this.canvasSize,
+    required this.onImageLoaded,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -129,6 +373,19 @@ class _BackgroundLayer extends StatelessWidget {
             child: Image.network(
               backgroundUrl,
               fit: BoxFit.contain,
+              frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+                if (frame != null) {
+                  // 이미지 로드 완료 - 크기 측정
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    _getImageSize(backgroundUrl).then((size) {
+                      if (size != null) {
+                        onImageLoaded(size);
+                      }
+                    });
+                  });
+                }
+                return child;
+              },
               errorBuilder: (context, error, stackTrace) {
                 return Container(
                   color: Colors.white,
@@ -156,6 +413,34 @@ class _BackgroundLayer extends StatelessWidget {
       },
     );
   }
+
+  Future<Size?> _getImageSize(String url) async {
+    try {
+      final imageProvider = NetworkImage(url);
+      final imageStream = imageProvider.resolve(const ImageConfiguration());
+      final completer = Completer<Size?>();
+
+      late ImageStreamListener listener;
+      listener = ImageStreamListener((ImageInfo info, bool synchronousCall) {
+        final image = info.image;
+        completer.complete(Size(
+          image.width.toDouble(),
+          image.height.toDouble(),
+        ));
+        imageStream.removeListener(listener);
+      }, onError: (dynamic error, StackTrace? stackTrace) {
+        debugPrint('Failed to get image size: $error');
+        completer.complete(null);
+        imageStream.removeListener(listener);
+      });
+
+      imageStream.addListener(listener);
+      return await completer.future;
+    } catch (e) {
+      debugPrint('Failed to get image size: $e');
+      return null;
+    }
+  }
 }
 
 /// ===============================
@@ -163,8 +448,14 @@ class _BackgroundLayer extends StatelessWidget {
 /// ===============================
 class _OthersDrawingLayer extends StatelessWidget {
   final Size canvasSize;
+  final Size? backgroundImageSize;
+  final double scale;
 
-  const _OthersDrawingLayer({required this.canvasSize});
+  const _OthersDrawingLayer({
+    required this.canvasSize,
+    required this.backgroundImageSize,
+    required this.scale,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -175,11 +466,18 @@ class _OthersDrawingLayer extends StatelessWidget {
             !_strokesEqual(previous, next);
       },
       builder: (context, strokes, child) {
+        final scaler = CoordinateScaler(
+          canvasSize: canvasSize,
+          contentSize: backgroundImageSize,
+          fit: BoxFit.contain,
+        );
+
         return Positioned.fill(
           child: CustomPaint(
             painter: DrawingPainter(
               strokes: strokes,
-              canvasSize: canvasSize,
+              scaler: scaler,
+              scale: scale, // 줌 레벨 전달
             ),
           ),
         );
@@ -202,8 +500,14 @@ class _OthersDrawingLayer extends StatelessWidget {
 /// ===============================
 class _MyDrawingLayer extends StatelessWidget {
   final Size canvasSize;
+  final Size? backgroundImageSize;
+  final double scale;
 
-  const _MyDrawingLayer({required this.canvasSize});
+  const _MyDrawingLayer({
+    required this.canvasSize,
+    required this.backgroundImageSize,
+    required this.scale,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -214,11 +518,18 @@ class _MyDrawingLayer extends StatelessWidget {
             !_strokesEqual(previous, next);
       },
       builder: (context, strokes, child) {
+        final scaler = CoordinateScaler(
+          canvasSize: canvasSize,
+          contentSize: backgroundImageSize,
+          fit: BoxFit.contain,
+        );
+
         return Positioned.fill(
           child: CustomPaint(
             painter: DrawingPainter(
               strokes: strokes,
-              canvasSize: canvasSize,
+              scaler: scaler,
+              scale: scale, // 줌 레벨 전달
             ),
           ),
         );
@@ -241,16 +552,20 @@ class _MyDrawingLayer extends StatelessWidget {
 /// ===============================
 class _TouchInputLayer extends StatelessWidget {
   final Size canvasSize;
+  final Size? backgroundImageSize;
   final int? currentStrokeId;
   final List<DrawPoint> currentPoints;
-  final Function(DragStartDetails, Size, DrawingProvider) onPanStart;
-  final Function(DragUpdateDetails, Size, DrawingProvider) onPanUpdate;
-  final Function(Size, DrawingProvider) onPanEnd;
+  final TransformationController transformationController;
+  final Function(DragStartDetails, CoordinateScaler, DrawingProvider) onPanStart;
+  final Function(DragUpdateDetails, CoordinateScaler, DrawingProvider) onPanUpdate;
+  final Function(CoordinateScaler, DrawingProvider) onPanEnd;
 
   const _TouchInputLayer({
     required this.canvasSize,
+    required this.backgroundImageSize,
     required this.currentStrokeId,
     required this.currentPoints,
+    required this.transformationController,
     required this.onPanStart,
     required this.onPanUpdate,
     required this.onPanEnd,
@@ -258,29 +573,28 @@ class _TouchInputLayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Selector<DrawingProvider, bool>(
-      selector: (context, provider) => provider.isDrawingMode,
-      builder: (context, isDrawingMode, child) {
-        if (!isDrawingMode) return const SizedBox.shrink();
+    final scaler = CoordinateScaler(
+      canvasSize: canvasSize,
+      contentSize: backgroundImageSize,
+      fit: BoxFit.contain,
+    );
 
-        return Positioned.fill(
-          child: GestureDetector(
-            onPanStart: (details) {
-              final provider = context.read<DrawingProvider>();
-              onPanStart(details, canvasSize, provider);
-            },
-            onPanUpdate: (details) {
-              final provider = context.read<DrawingProvider>();
-              onPanUpdate(details, canvasSize, provider);
-            },
-            onPanEnd: (details) {
-              final provider = context.read<DrawingProvider>();
-              onPanEnd(canvasSize, provider);
-            },
-            child: Container(color: Colors.transparent),
-          ),
-        );
-      },
+    return Positioned.fill(
+      child: GestureDetector(
+        onPanStart: (details) {
+          final provider = context.read<DrawingProvider>();
+          onPanStart(details, scaler, provider);
+        },
+        onPanUpdate: (details) {
+          final provider = context.read<DrawingProvider>();
+          onPanUpdate(details, scaler, provider);
+        },
+        onPanEnd: (details) {
+          final provider = context.read<DrawingProvider>();
+          onPanEnd(scaler, provider);
+        },
+        child: Container(color: Colors.transparent),
+      ),
     );
   }
 }
@@ -306,7 +620,7 @@ class _SocketStatusIndicator extends StatelessWidget {
               Container(
                 width: 8,
                 height: 8,
-                decoration: BoxDecoration(
+                decoration: const BoxDecoration(
                   color: Colors.white,
                   shape: BoxShape.circle,
                 ),
@@ -324,6 +638,166 @@ class _SocketStatusIndicator extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+/// ===============================
+/// 줌 레벨 표시
+/// ===============================
+class _ZoomIndicator extends StatelessWidget {
+  final double scale;
+
+  const _ZoomIndicator({required this.scale});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.black54,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(
+            Icons.zoom_in,
+            color: Colors.white,
+            size: 16,
+          ),
+          const SizedBox(width: 4),
+          Text(
+            '${(scale * 100).toStringAsFixed(0)}%',
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// ===============================
+/// 개인 필기 레이어 (학생용)
+/// ===============================
+class _PersonalDrawingLayer extends StatelessWidget {
+  final Size canvasSize;
+  final Size? backgroundImageSize;
+  final double scale;
+
+  const _PersonalDrawingLayer({
+    required this.canvasSize,
+    required this.backgroundImageSize,
+    required this.scale,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Selector<PersonalDrawingProvider, ({bool show, List<Stroke> strokes})>(
+      selector: (context, provider) => (
+      show: provider.showPersonalLayer,
+      strokes: provider.allPersonalStrokes,
+      ),
+      shouldRebuild: (previous, next) {
+        return previous.show != next.show ||
+            previous.strokes.length != next.strokes.length ||
+            !_strokesEqual(previous.strokes, next.strokes);
+      },
+      builder: (context, data, child) {
+        if (!data.show) {
+          return const SizedBox.shrink();
+        }
+
+        final scaler = CoordinateScaler(
+          canvasSize: canvasSize,
+          contentSize: backgroundImageSize,
+          fit: BoxFit.contain,
+        );
+
+        return Positioned.fill(
+          child: CustomPaint(
+            painter: DrawingPainter(
+              strokes: data.strokes,
+              scaler: scaler,
+              scale: scale,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  bool _strokesEqual(List<Stroke> a, List<Stroke> b) {
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i].strokeId != b[i].strokeId) return false;
+      if (a[i].points.length != b[i].points.length) return false;
+    }
+    return true;
+  }
+}
+
+/// ===============================
+/// 개인 필기 터치 입력 레이어 (학생용)
+/// ===============================
+class _PersonalTouchInputLayer extends StatelessWidget {
+  final Size canvasSize;
+  final Size? backgroundImageSize;
+  final int? currentStrokeId;
+  final List<DrawPoint> currentPoints;
+  final TransformationController transformationController;
+  final Function(DragStartDetails, CoordinateScaler, PersonalDrawingProvider, Color, double) onPanStart;
+  final Function(DragUpdateDetails, CoordinateScaler, PersonalDrawingProvider) onPanUpdate;
+  final Function(CoordinateScaler, PersonalDrawingProvider) onPanEnd;
+
+  const _PersonalTouchInputLayer({
+    required this.canvasSize,
+    required this.backgroundImageSize,
+    required this.currentStrokeId,
+    required this.currentPoints,
+    required this.transformationController,
+    required this.onPanStart,
+    required this.onPanUpdate,
+    required this.onPanEnd,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scaler = CoordinateScaler(
+      canvasSize: canvasSize,
+      contentSize: backgroundImageSize,
+      fit: BoxFit.contain,
+    );
+
+    return Positioned.fill(
+      child: Consumer<PersonalDrawingProvider>(
+        builder: (context, personalProvider, child) {
+          final drawingProvider = context.read<DrawingProvider>();
+
+          return GestureDetector(
+            onPanStart: (details) {
+              onPanStart(
+                details,
+                scaler,
+                personalProvider,
+                drawingProvider.currentColor,
+                drawingProvider.currentWidth,
+              );
+            },
+            onPanUpdate: (details) {
+              onPanUpdate(details, scaler, personalProvider);
+            },
+            onPanEnd: (details) {
+              onPanEnd(scaler, personalProvider);
+            },
+            child: Container(color: Colors.transparent),
+          );
+        },
+      ),
     );
   }
 }

--- a/pentalk_front/lib/widgets/participants_bottom_sheet.dart
+++ b/pentalk_front/lib/widgets/participants_bottom_sheet.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/participant_model.dart';
+import '../providers/participants_provider.dart';
+
+/// ===============================
+/// 참여자 목록 바텀시트
+/// ===============================
+class ParticipantsBottomSheet extends StatelessWidget {
+  const ParticipantsBottomSheet({Key? key}) : super(key: key);
+
+  static void show(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => const ParticipantsBottomSheet(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: MediaQuery.of(context).size.height * 0.6,
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        children: [
+          // 핸들
+          Container(
+            margin: const EdgeInsets.only(top: 12),
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: Colors.grey[300],
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+
+          // 헤더
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: StreamBuilder<List<Participant>>(
+              stream: context.read<ParticipantsProvider>().participantsStream,
+              builder: (context, snapshot) {
+                final provider = context.watch<ParticipantsProvider>();
+
+                return Row(
+                  children: [
+                    const Icon(Icons.people, size: 24),
+                    const SizedBox(width: 8),
+                    Text(
+                      '참여자',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const Spacer(),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 6,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Colors.blue[50],
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Text(
+                        '${provider.totalCount}명',
+                        style: TextStyle(
+                          color: Colors.blue[700],
+                          fontWeight: FontWeight.bold,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+
+          const Divider(height: 1),
+
+          // 참여자 목록
+          Expanded(
+            child: StreamBuilder<List<Participant>>(
+              stream: context.read<ParticipantsProvider>().participantsStream,
+              initialData: context.read<ParticipantsProvider>().participants,
+              builder: (context, snapshot) {
+                if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                  return const Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.people_outline, size: 64, color: Colors.grey),
+                        SizedBox(height: 16),
+                        Text(
+                          '참여자가 없습니다',
+                          style: TextStyle(color: Colors.grey, fontSize: 16),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+
+                final participants = snapshot.data!;
+                final teachers = participants.where((p) => p.isTeacher).toList();
+                final students = participants.where((p) => p.isStudent).toList();
+
+                return ListView(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  children: [
+                    // 교사 섹션
+                    if (teachers.isNotEmpty) ...[
+                      _SectionHeader(
+                        title: '교사',
+                        count: teachers.length,
+                        icon: Icons.school,
+                        color: Colors.blue,
+                      ),
+                      ...teachers.map((p) => _ParticipantTile(participant: p)),
+                      const SizedBox(height: 16),
+                    ],
+
+                    // 학생 섹션
+                    if (students.isNotEmpty) ...[
+                      _SectionHeader(
+                        title: '학생',
+                        count: students.length,
+                        icon: Icons.person,
+                        color: Colors.green,
+                      ),
+                      ...students.map((p) => _ParticipantTile(participant: p)),
+                    ],
+                  ],
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// ===============================
+/// 섹션 헤더
+/// ===============================
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  final int count;
+  final IconData icon;
+  final Color color;
+
+  const _SectionHeader({
+    required this.title,
+    required this.count,
+    required this.icon,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Row(
+        children: [
+          Icon(icon, size: 20, color: color),
+          const SizedBox(width: 8),
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+              color: Colors.grey[700],
+            ),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            '($count)',
+            style: TextStyle(
+              fontSize: 14,
+              color: Colors.grey[500],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// ===============================
+/// 참여자 타일
+/// ===============================
+class _ParticipantTile extends StatelessWidget {
+  final Participant participant;
+
+  const _ParticipantTile({required this.participant});
+
+  @override
+  Widget build(BuildContext context) {
+    final isTeacher = participant.isTeacher;
+    final color = isTeacher ? Colors.blue : Colors.green;
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      leading: CircleAvatar(
+        backgroundColor: color.withOpacity(0.1),
+        child: Icon(
+          isTeacher ? Icons.school : Icons.person,
+          color: color,
+          size: 20,
+        ),
+      ),
+      title: Text(
+        participant.userId,
+        style: TextStyle(
+          fontSize: 15,
+          fontWeight: isTeacher ? FontWeight.bold : FontWeight.normal,
+        ),
+      ),
+      trailing: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: color.withOpacity(0.1),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: color.withOpacity(0.3), width: 1),
+        ),
+        child: Text(
+          isTeacher ? '교사' : '학생',
+          style: TextStyle(
+            fontSize: 12,
+            color: color[700],
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pentalk_front/lib/widgets/participants_button.dart
+++ b/pentalk_front/lib/widgets/participants_button.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/participant_model.dart';
+import '../providers/participants_provider.dart';
+import '../widgets/participants_bottom_sheet.dart';
+
+/// ===============================
+/// 참여자 버튼 (AppBar용)
+/// ===============================
+class ParticipantsButton extends StatelessWidget {
+  const ParticipantsButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<List<Participant>>(
+      stream: context.read<ParticipantsProvider>().participantsStream,
+      initialData: context.read<ParticipantsProvider>().participants,
+      builder: (context, snapshot) {
+        final count = snapshot.data?.length ?? 0;
+
+        return IconButton(
+          icon: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              const Icon(Icons.people_outline),
+              // 참여자 수 배지
+              if (count > 0)
+                Positioned(
+                  right: -2,
+                  top: -2,
+                  child: Container(
+                    padding: const EdgeInsets.all(2),
+                    decoration: BoxDecoration(
+                      color: Colors.red,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: Colors.white, width: 1.5),
+                    ),
+                    constraints: const BoxConstraints(
+                      minWidth: 18,
+                      minHeight: 18,
+                    ),
+                    child: Center(
+                      child: Text(
+                        count > 99 ? '99+' : '$count',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 10,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          onPressed: () {
+            ParticipantsBottomSheet.show(context);
+          },
+          tooltip: '참여자 목록',
+        );
+      },
+    );
+  }
+}

--- a/pentalk_front/lib/widgets/session_ended_dialog.dart
+++ b/pentalk_front/lib/widgets/session_ended_dialog.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+
+/// ===============================
+/// 세션 종료 관련 다이얼로그
+/// ===============================
+class SessionEndedDialog {
+  /// 교사용: 세션 종료 확인 팝업
+  static Future<bool> showEndConfirmation(BuildContext context) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: Row(
+          children: const [
+            Icon(Icons.logout, color: Colors.orange),
+            SizedBox(width: 12),
+            Text('세션 종료'),
+          ],
+        ),
+        content: const Text(
+          '세션을 종료하시겠습니까?\n\n'
+              '모든 학생이 수업에서 나가게 되며,\n'
+              '판서 내용은 서버에 저장됩니다.',
+          style: TextStyle(fontSize: 15),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('취소'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+            ),
+            child: const Text(
+              '종료',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return result ?? false;
+  }
+
+  /// 학생용: 세션 종료 알림 팝업
+  static Future<void> showStudentNotification(
+      BuildContext context, {
+        required String message,
+        required VoidCallback onConfirm,
+      }) async {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: Row(
+          children: const [
+            Icon(Icons.info_outline, color: Colors.blue),
+            SizedBox(width: 12),
+            Text('수업 종료'),
+          ],
+        ),
+        content: Text(
+          message,
+          style: const TextStyle(fontSize: 15),
+        ),
+        actions: [
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context);
+              onConfirm();
+            },
+            child: const Text(
+              '확인',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 세션 종료 중 로딩 팝업
+  static Future<void> showEndingProgress(BuildContext context) async {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => WillPopScope(
+        onWillPop: () async => false,
+        child: AlertDialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: const [
+              CircularProgressIndicator(),
+              SizedBox(height: 16),
+              Text('세션을 종료하는 중...'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// SESSION_ENDED 에러 팝업 (종료된 세션 재입장 시도)
+  static Future<void> showSessionAlreadyEnded(BuildContext context) async {
+    return showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: Row(
+          children: const [
+            Icon(Icons.block, color: Colors.red),
+            SizedBox(width: 12),
+            Text('입장 불가'),
+          ],
+        ),
+        content: const Text(
+          '이미 종료된 세션입니다.\n입장할 수 없습니다.',
+          style: TextStyle(fontSize: 15),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pentalk_front/pubspec.yaml
+++ b/pentalk_front/pubspec.yaml
@@ -32,14 +32,21 @@ dependencies:
     sdk: flutter
 
   qr_flutter: ^4.1.0
+  app_links: ^7.0.0
   provider: ^6.1.2
   share_plus: ^10.0.2
   cupertino_icons: ^1.0.8
   socket_io_client: ^2.0.3+1
+  shared_preferences: ^2.2.2
+  http: ^1.1.0
+
   # 파일 선택
   file_picker: ^6.1.1
   # 날짜 포맷팅
   intl: ^0.19.0
+  # SQLite 로컬 DB
+  sqflite: ^2.3.0
+  path: ^1.8.3
 
 
 dev_dependencies:

--- a/pentalk_front/pubspec.yaml
+++ b/pentalk_front/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   socket_io_client: ^2.0.3+1
   shared_preferences: ^2.2.2
   http: ^1.1.0
+  flutter_secure_storage: ^9.0.0
 
   # 파일 선택
   file_picker: ^6.1.1


### PR DESCRIPTION
## 구현

1. 저장된 판서 데이터 조회 API

GET /sessions/:sessionId/whiteboard
응답: { sessionId, readOnly, strokes: [...] }

2. 읽기 전용 DrawingScreen

isReadOnly 파라미터 추가
편집 버튼 모두 숨김
읽기 전용 배지 표시

3. 판서 데이터 로드

API로 strokes 가져오기
DrawingProvider에 자동 로드
정적 뷰어 (모든 선 한번에 표시)

## 관련 이슈
closes  #30