### PR TITLE
[Feat] 복습 퀴즈 기능 구현

### DIFF
--- a/pentalk_front/lib/main.dart
+++ b/pentalk_front/lib/main.dart
@@ -10,6 +10,7 @@ import 'providers/personal_drawing_provider.dart';
 import 'providers/participants_provider.dart';
 import 'providers/material_provider.dart';
 import 'screens/splash_screen.dart';
+import 'providers/quiz_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -36,6 +37,7 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => ParticipantsProvider()),
         ChangeNotifierProvider(create: (_) => PollProvider()),
         ChangeNotifierProvider(create: (_) => MaterialProvider()),
+        ChangeNotifierProvider(create: (_) => QuizProvider()),
       ],
       child: MaterialApp(
         title: '하이브리드 교실',

--- a/pentalk_front/lib/models/quiz_model.dart
+++ b/pentalk_front/lib/models/quiz_model.dart
@@ -1,0 +1,108 @@
+/// ===============================
+/// 복습 퀴즈 모델
+/// OX 형식 / 세션당 최대 3문제
+/// ===============================
+
+/// 퀴즈 문항 (교사 등록 + 학생 수행 공용)
+class QuizQuestion {
+  final String id;
+  final String question;
+
+  /// 교사 응답에만 포함됨 ('O' 또는 'X')
+  /// 학생용 GET 응답에는 null
+  final String? answer;
+
+  final int order; // 1·2·3
+
+  final DateTime? createdAt;
+
+  const QuizQuestion({
+    required this.id,
+    required this.question,
+    this.answer,
+    required this.order,
+    this.createdAt,
+  });
+
+  factory QuizQuestion.fromJson(Map<String, dynamic> json) {
+    return QuizQuestion(
+      id: json['id'] as String,
+      question: json['question'] as String,
+      answer: json['answer'] as String?,
+      order: (json['order'] as num).toInt(),
+      createdAt: json['createdAt'] != null
+          ? DateTime.tryParse(json['createdAt'] as String)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'question': question,
+      if (answer != null) 'answer': answer,
+      'order': order,
+      if (createdAt != null) 'createdAt': createdAt!.toIso8601String(),
+    };
+  }
+
+  QuizQuestion copyWith({
+    String? id,
+    String? question,
+    String? answer,
+    int? order,
+    DateTime? createdAt,
+  }) {
+    return QuizQuestion(
+      id: id ?? this.id,
+      question: question ?? this.question,
+      answer: answer ?? this.answer,
+      order: order ?? this.order,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}
+
+/// 답안 제출 결과 (POST /quiz/submit 응답)
+class QuizSubmitResult {
+  final String questionId;
+  final bool isCorrect;
+  final String submittedAnswer;
+  final String correctAnswer;
+
+  const QuizSubmitResult({
+    required this.questionId,
+    required this.isCorrect,
+    required this.submittedAnswer,
+    required this.correctAnswer,
+  });
+
+  factory QuizSubmitResult.fromJson(Map<String, dynamic> json) {
+    return QuizSubmitResult(
+      questionId: json['questionId'] as String,
+      isCorrect: json['isCorrect'] as bool,
+      submittedAnswer: json['submittedAnswer'] as String,
+      correctAnswer: json['correctAnswer'] as String,
+    );
+  }
+}
+
+/// 퀴즈 전체 상태
+enum QuizStatus {
+  idle,              // 초기 상태
+  loading,           // 문항 불러오는 중
+  ready,             // 문항 로드 완료, 답변 대기
+  submitting,        // 제출 중
+  passed,            // 통과 (60% 이상)
+  failed,            // 미통과 (60% 미만)
+  dailyLimitExceeded,// 하루 2회 초과 (429)
+  noQuestions,       // 등록된 문항 없음
+}
+
+/// 하루 2회 초과 예외
+class QuizDailyLimitException implements Exception {
+  const QuizDailyLimitException();
+
+  @override
+  String toString() => '하루 최대 2회까지 응시할 수 있습니다';
+}

--- a/pentalk_front/lib/providers/drawing_provider.dart
+++ b/pentalk_front/lib/providers/drawing_provider.dart
@@ -910,12 +910,11 @@ class DrawingProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void disconnectSocket() {
-    _socketService.disconnect();
-    _isSocketConnected = false;
-    notifyListeners();
-  }
-
+    void disconnectSocket() {
+      _socketService.disconnect();
+      _isSocketConnected = false;
+      notifyListeners();
+    }
   void _handleSessionEnded(Map<String, dynamic> data) {
     onSessionEnded?.call(data);
   }

--- a/pentalk_front/lib/providers/quiz_provider.dart
+++ b/pentalk_front/lib/providers/quiz_provider.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/foundation.dart';
+import '../models/quiz_model.dart';
+import '../services/api_service.dart';
+
+/// ===============================
+/// 복습 퀴즈 Provider
+/// 학생 수행 + 교사 등록/관리 공용
+/// ===============================
+class QuizProvider extends ChangeNotifier {
+  // ── 공통 상태 ────────────────────────────────────────────
+  List<QuizQuestion> _questions = [];
+  QuizStatus _status = QuizStatus.idle;
+  String? _errorMessage;
+
+  // ── 학생 전용 상태 ────────────────────────────────────────
+  /// questionId → 'O' | 'X'
+  final Map<String, String> _studentAnswers = {};
+
+  /// questionId → 제출 결과
+  final Map<String, QuizSubmitResult> _results = {};
+
+  // ── Getters ───────────────────────────────────────────────
+  List<QuizQuestion> get questions =>
+      List.unmodifiable(_questions..sort((a, b) => a.order.compareTo(b.order)));
+
+  QuizStatus get status => _status;
+  String? get errorMessage => _errorMessage;
+
+  Map<String, String> get studentAnswers =>
+      Map.unmodifiable(_studentAnswers);
+
+  Map<String, QuizSubmitResult> get results =>
+      Map.unmodifiable(_results);
+
+  /// 모든 문항에 답변 완료 여부
+  bool get allAnswered =>
+      _questions.isNotEmpty &&
+          _questions.every((q) => _studentAnswers.containsKey(q.id));
+
+  /// 정답 수
+  int get correctCount => _results.values.where((r) => r.isCorrect).length;
+
+  /// 전체 문항 수
+  int get totalCount => _questions.length;
+
+  /// 통과 여부 (60% 이상)
+  bool get passed =>
+      _questions.isNotEmpty && correctCount / _questions.length >= 0.6;
+
+  /// 교사가 추가 가능한지 (최대 3문항)
+  bool get canAddQuestion => _questions.length < 3;
+
+  // ── 학생: 문항 로드 ──────────────────────────────────────
+  Future<void> loadQuestionsForStudent(String sessionId) async {
+    _setStatus(QuizStatus.loading);
+
+    try {
+      final questions =
+      await ApiService.getQuizQuestions(sessionId: sessionId);
+
+      if (questions.isEmpty) {
+        _questions = [];
+        _setStatus(QuizStatus.noQuestions);
+        return;
+      }
+
+      _questions = questions;
+      _setStatus(QuizStatus.ready);
+    } catch (e) {
+      _errorMessage = '퀴즈를 불러오지 못했습니다';
+      _setStatus(QuizStatus.idle);
+      debugPrint('QuizProvider.loadQuestionsForStudent error: $e');
+    }
+  }
+
+  // ── 학생: 답변 선택 ──────────────────────────────────────
+  void setAnswer(String questionId, String answer) {
+    assert(answer == 'O' || answer == 'X', 'OX 퀴즈 답변은 O 또는 X여야 합니다');
+    _studentAnswers[questionId] = answer;
+    notifyListeners();
+  }
+
+  // ── 학생: 전체 제출 ──────────────────────────────────────
+  Future<void> submitAll(String sessionId) async {
+    if (!allAnswered) return;
+
+    _setStatus(QuizStatus.submitting);
+
+    try {
+      // 문항 순서대로 순차 제출
+      for (final question in _questions) {
+        final answer = _studentAnswers[question.id]!;
+        final result = await ApiService.submitQuizAnswer(
+          sessionId: sessionId,
+          questionId: question.id,
+          answer: answer,
+        );
+        _results[question.id] = result;
+      }
+
+      _setStatus(passed ? QuizStatus.passed : QuizStatus.failed);
+    } on QuizDailyLimitException {
+      _errorMessage = '오늘 응시 횟수를 모두 사용했습니다.\n내일 다시 도전해주세요.';
+      _setStatus(QuizStatus.dailyLimitExceeded);
+    } catch (e) {
+      _errorMessage = '제출 중 오류가 발생했습니다. 다시 시도해주세요.';
+      _setStatus(QuizStatus.failed);
+      debugPrint('QuizProvider.submitAll error: $e');
+    }
+  }
+
+  // ── 학생: 재시도 준비 ────────────────────────────────────
+  void resetForRetry() {
+    _studentAnswers.clear();
+    _results.clear();
+    _errorMessage = null;
+    _setStatus(QuizStatus.ready);
+  }
+
+  // ── 교사: 문항 로드 ──────────────────────────────────────
+  Future<void> loadQuestionsForTeacher(String sessionId) async {
+    _setStatus(QuizStatus.loading);
+
+    try {
+      final questions =
+      await ApiService.getQuizQuestions(sessionId: sessionId);
+      _questions = questions;
+      _setStatus(QuizStatus.ready);
+    } catch (e) {
+      _errorMessage = '퀴즈를 불러오지 못했습니다';
+      _setStatus(QuizStatus.idle);
+      debugPrint('QuizProvider.loadQuestionsForTeacher error: $e');
+    }
+  }
+
+  // ── 교사: 문항 추가 ──────────────────────────────────────
+  Future<void> addQuestion(
+      String sessionId, {
+        required String question,
+        required String answer,
+      }) async {
+    if (!canAddQuestion) throw Exception('최대 3문항까지 등록할 수 있습니다');
+
+    final nextOrder = _questions.isEmpty
+        ? 1
+        : (_questions.map((q) => q.order).reduce((a, b) => a > b ? a : b) + 1)
+        .clamp(1, 3);
+
+    final newQuestion = await ApiService.addQuizQuestion(
+      sessionId: sessionId,
+      question: question,
+      answer: answer,
+      order: nextOrder,
+    );
+
+    _questions = [..._questions, newQuestion];
+    notifyListeners();
+  }
+
+  // ── 교사: 문항 수정 ──────────────────────────────────────
+  Future<void> updateQuestion(
+      String sessionId,
+      String questionId, {
+        String? question,
+        String? answer,
+      }) async {
+    final updated = await ApiService.updateQuizQuestion(
+      sessionId: sessionId,
+      questionId: questionId,
+      question: question,
+      answer: answer,
+    );
+
+    final index = _questions.indexWhere((q) => q.id == questionId);
+    if (index != -1) {
+      final list = List<QuizQuestion>.from(_questions);
+      list[index] = updated;
+      _questions = list;
+      notifyListeners();
+    }
+  }
+
+  // ── 교사: 문항 삭제 ──────────────────────────────────────
+  Future<void> deleteQuestion(String sessionId, String questionId) async {
+    await ApiService.deleteQuizQuestion(
+      sessionId: sessionId,
+      questionId: questionId,
+    );
+
+    _questions = _questions.where((q) => q.id != questionId).toList();
+    notifyListeners();
+  }
+
+  // ── 초기화 ────────────────────────────────────────────────
+  void clear() {
+    _questions = [];
+    _studentAnswers.clear();
+    _results.clear();
+    _status = QuizStatus.idle;
+    _errorMessage = null;
+    notifyListeners();
+  }
+
+  // ── 내부 헬퍼 ─────────────────────────────────────────────
+  void _setStatus(QuizStatus status) {
+    _status = status;
+    notifyListeners();
+  }
+}

--- a/pentalk_front/lib/screens/drawing_screen.dart
+++ b/pentalk_front/lib/screens/drawing_screen.dart
@@ -24,6 +24,7 @@ import '../services/api_service.dart';
 import '../services/pdf_document_service.dart';
 import '../services/pdf_export_service.dart';
 import '../services/pdf_file_service.dart';
+import '../screens/quiz_screen.dart';
 
 class DrawingScreen extends StatefulWidget {
   final String materialTitle;
@@ -412,7 +413,17 @@ class _DrawingScreenState extends State<DrawingScreen> {
       SessionEndedDialog.showStudentNotification(
         context,
         message: message,
-        onConfirm: _cleanupAndGoHome,
+        onConfirm: () {
+          QuizScreen.show(
+            context,
+            sessionId: widget.sessionId ?? widget.roomId ?? '',
+            onPassed: () {
+              _handleExportPdf();
+              _cleanupAndGoHome();
+            },
+            onClose: _cleanupAndGoHome,
+          );
+        },
       );
     }
   }

--- a/pentalk_front/lib/screens/quiz_screen.dart
+++ b/pentalk_front/lib/screens/quiz_screen.dart
@@ -1,0 +1,847 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/quiz_model.dart';
+import '../providers/quiz_provider.dart';
+
+/// ===============================
+/// 학생용 복습 퀴즈 화면
+/// session:ended 이후 표시
+/// 60% 이상 통과 시 PDF 다운로드 활성화
+/// ===============================
+class QuizScreen extends StatefulWidget {
+  final String sessionId;
+
+  /// 통과 시 호출 → PDF 다운로드 트리거
+  final VoidCallback onPassed;
+
+  /// 퀴즈 없이 닫을 때 (noQuestions 등)
+  final VoidCallback onClose;
+
+  const QuizScreen({
+    Key? key,
+    required this.sessionId,
+    required this.onPassed,
+    required this.onClose,
+  }) : super(key: key);
+
+  /// 전체 화면 모달로 표시
+  static Future<void> show(
+      BuildContext context, {
+        required String sessionId,
+        required VoidCallback onPassed,
+        required VoidCallback onClose,
+      }) {
+    return Navigator.of(context).push(
+      MaterialPageRoute(
+        fullscreenDialog: true,
+        builder: (_) => ChangeNotifierProvider(
+          create: (_) => QuizProvider(),
+          child: QuizScreen(
+            sessionId: sessionId,
+            onPassed: onPassed,
+            onClose: onClose,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  State<QuizScreen> createState() => _QuizScreenState();
+}
+
+class _QuizScreenState extends State<QuizScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<QuizProvider>().loadQuestionsForStudent(widget.sessionId);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false, // 뒤로가기 비활성화 (퀴즈 중간 이탈 방지)
+      child: Scaffold(
+        backgroundColor: const Color(0xFFF5F7FA),
+        body: SafeArea(
+          child: Consumer<QuizProvider>(
+            builder: (context, provider, _) {
+              return switch (provider.status) {
+                QuizStatus.idle || QuizStatus.loading => const _LoadingView(),
+                QuizStatus.noQuestions => _NoQuestionsView(onClose: widget.onClose),
+                QuizStatus.ready => _QuizFormView(
+                  provider: provider,
+                  onSubmit: () => provider.submitAll(widget.sessionId),
+                ),
+                QuizStatus.submitting => const _LoadingView(
+                  message: '채점 중...',
+                ),
+                QuizStatus.passed => _ResultView(
+                  provider: provider,
+                  passed: true,
+                  onPdfDownload: () {
+                    Navigator.pop(context);
+                    widget.onPassed();
+                  },
+                  onClose: () {
+                    Navigator.pop(context);
+                    widget.onClose();
+                  },
+                ),
+                QuizStatus.failed => _ResultView(
+                  provider: provider,
+                  passed: false,
+                  onRetry: () => provider.resetForRetry(),
+                  onClose: () {
+                    Navigator.pop(context);
+                    widget.onClose();
+                  },
+                ),
+                QuizStatus.dailyLimitExceeded => _DailyLimitView(
+                  message: provider.errorMessage ?? '오늘 응시 횟수를 모두 사용했습니다.',
+                  onClose: () {
+                    Navigator.pop(context);
+                    widget.onClose();
+                  },
+                ),
+              };
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── 로딩 뷰 ─────────────────────────────────────────────────
+class _LoadingView extends StatelessWidget {
+  final String message;
+
+  const _LoadingView({this.message = '퀴즈를 불러오는 중...'});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: 20),
+          Text(message, style: const TextStyle(fontSize: 16, color: Colors.grey)),
+        ],
+      ),
+    );
+  }
+}
+
+// ── 문항 없음 뷰 ──────────────────────────────────────────────
+class _NoQuestionsView extends StatelessWidget {
+  final VoidCallback onClose;
+
+  const _NoQuestionsView({required this.onClose});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.quiz_outlined, size: 72, color: Colors.grey[400]),
+            const SizedBox(height: 20),
+            Text(
+              '등록된 퀴즈가 없습니다',
+              style: TextStyle(fontSize: 20, color: Colors.grey[600]),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '교사가 퀴즈를 등록하지 않았습니다.\nPDF를 바로 다운로드할 수 있습니다.',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 14, color: Colors.grey[500]),
+            ),
+            const SizedBox(height: 32),
+            ElevatedButton(
+              onPressed: onClose,
+              child: const Text('닫기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── 퀴즈 폼 뷰 ───────────────────────────────────────────────
+class _QuizFormView extends StatelessWidget {
+  final QuizProvider provider;
+  final VoidCallback onSubmit;
+
+  const _QuizFormView({required this.provider, required this.onSubmit});
+
+  @override
+  Widget build(BuildContext context) {
+    final questions = provider.questions;
+
+    return Column(
+      children: [
+        // 헤더
+        _QuizHeader(totalCount: questions.length),
+
+        // 문항 목록
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              children: [
+                for (int i = 0; i < questions.length; i++) ...[
+                  _QuestionCard(
+                    index: i,
+                    question: questions[i],
+                    selectedAnswer: provider.studentAnswers[questions[i].id],
+                    onAnswerSelected: (answer) =>
+                        provider.setAnswer(questions[i].id, answer),
+                  ),
+                  if (i < questions.length - 1) const SizedBox(height: 16),
+                ],
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        ),
+
+        // 제출 버튼
+        _SubmitBar(
+          answeredCount: provider.studentAnswers.length,
+          totalCount: questions.length,
+          canSubmit: provider.allAnswered,
+          onSubmit: onSubmit,
+        ),
+      ],
+    );
+  }
+}
+
+// ── 퀴즈 헤더 ────────────────────────────────────────────────
+class _QuizHeader extends StatelessWidget {
+  final int totalCount;
+
+  const _QuizHeader({required this.totalCount});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.06),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding:
+                const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                decoration: BoxDecoration(
+                  color: Colors.blue[50],
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Text(
+                  '복습 퀴즈',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.blue[700],
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'PDF를 받으려면 퀴즈를 통과하세요',
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '$totalCount문제 중 ${(totalCount * 0.6).ceil()}문제 이상 맞히면 통과!',
+            style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── 문항 카드 ─────────────────────────────────────────────────
+class _QuestionCard extends StatelessWidget {
+  final int index;
+  final QuizQuestion question;
+  final String? selectedAnswer;
+  final ValueChanged<String> onAnswerSelected;
+
+  const _QuestionCard({
+    required this.index,
+    required this.question,
+    required this.selectedAnswer,
+    required this.onAnswerSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.06),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 문항 번호 + 텍스트
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 28,
+                  height: 28,
+                  decoration: BoxDecoration(
+                    color: Colors.blue[600],
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: Text(
+                      '${index + 1}',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    question.question,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                      height: 1.5,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            // O / X 버튼
+            Row(
+              children: [
+                Expanded(
+                  child: _OxButton(
+                    label: 'O',
+                    isSelected: selectedAnswer == 'O',
+                    color: Colors.green,
+                    onTap: () => onAnswerSelected('O'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _OxButton(
+                    label: 'X',
+                    isSelected: selectedAnswer == 'X',
+                    color: Colors.red,
+                    onTap: () => onAnswerSelected('X'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── OX 버튼 ──────────────────────────────────────────────────
+class _OxButton extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final Color color;
+  final VoidCallback onTap;
+
+  const _OxButton({
+    required this.label,
+    required this.isSelected,
+    required this.color,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 180),
+      height: 56,
+      decoration: BoxDecoration(
+        color: isSelected ? color.withOpacity(0.12) : Colors.grey[50],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isSelected ? color : Colors.grey[300]!,
+          width: isSelected ? 2.5 : 1,
+        ),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Center(
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 26,
+              fontWeight: FontWeight.bold,
+              color: isSelected ? color : Colors.grey[400],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── 제출 바 ──────────────────────────────────────────────────
+class _SubmitBar extends StatelessWidget {
+  final int answeredCount;
+  final int totalCount;
+  final bool canSubmit;
+  final VoidCallback onSubmit;
+
+  const _SubmitBar({
+    required this.answeredCount,
+    required this.totalCount,
+    required this.canSubmit,
+    required this.onSubmit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.06),
+            blurRadius: 8,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (!canSubmit)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(
+                  '$answeredCount / $totalCount 문제 답변 완료',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 13, color: Colors.grey[500]),
+                ),
+              ),
+            ElevatedButton(
+              onPressed: canSubmit ? onSubmit : null,
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                backgroundColor: Colors.blue[600],
+                foregroundColor: Colors.white,
+                disabledBackgroundColor: Colors.grey[200],
+              ),
+              child: Text(
+                canSubmit ? '제출하기' : '모든 문제에 답해주세요',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── 결과 뷰 (통과/미통과) ────────────────────────────────────
+class _ResultView extends StatelessWidget {
+  final QuizProvider provider;
+  final bool passed;
+  final VoidCallback? onPdfDownload; // 통과 시
+  final VoidCallback? onRetry; // 미통과 시
+  final VoidCallback onClose;
+
+  const _ResultView({
+    required this.provider,
+    required this.passed,
+    this.onPdfDownload,
+    this.onRetry,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final questions = provider.questions;
+    final results = provider.results;
+
+    return Column(
+      children: [
+        // 결과 배너
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            color: passed ? Colors.green[600] : Colors.orange[600],
+          ),
+          child: Column(
+            children: [
+              Icon(
+                passed ? Icons.celebration : Icons.refresh,
+                color: Colors.white,
+                size: 48,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                passed ? '통과!' : '아쉽지만 미통과',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '${provider.correctCount} / ${provider.totalCount} 정답',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 16,
+                ),
+              ),
+              if (!passed)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    '통과 기준: ${(provider.totalCount * 0.6).ceil()}문제 이상',
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.85),
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+
+        // 문항별 결과 목록
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              children: [
+                for (int i = 0; i < questions.length; i++) ...[
+                  _ResultCard(
+                    index: i,
+                    question: questions[i],
+                    result: results[questions[i].id],
+                  ),
+                  if (i < questions.length - 1) const SizedBox(height: 12),
+                ],
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        ),
+
+        // 하단 버튼
+        Container(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.06),
+                blurRadius: 8,
+                offset: const Offset(0, -2),
+              ),
+            ],
+          ),
+          child: SafeArea(
+            top: false,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (passed)
+                  ElevatedButton.icon(
+                    onPressed: onPdfDownload,
+                    icon: const Icon(Icons.picture_as_pdf),
+                    label: const Text(
+                      'PDF 다운로드',
+                      style: TextStyle(
+                          fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    style: ElevatedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      backgroundColor: Colors.green[600],
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                  )
+                else ...[
+                  ElevatedButton(
+                    onPressed: onRetry,
+                    style: ElevatedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      backgroundColor: Colors.blue[600],
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                    child: const Text(
+                      '다시 도전',
+                      style: TextStyle(
+                          fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton(
+                    onPressed: onClose,
+                    child: Text(
+                      '나중에 하기',
+                      style: TextStyle(color: Colors.grey[600]),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── 문항별 결과 카드 ─────────────────────────────────────────
+class _ResultCard extends StatelessWidget {
+  final int index;
+  final QuizQuestion question;
+  final QuizSubmitResult? result;
+
+  const _ResultCard({
+    required this.index,
+    required this.question,
+    required this.result,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isCorrect = result?.isCorrect ?? false;
+    final color = isCorrect ? Colors.green : Colors.red;
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: color.withOpacity(0.3),
+          width: 1.5,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 정오 아이콘
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              color: color.withOpacity(0.1),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              isCorrect ? Icons.check : Icons.close,
+              color: color,
+              size: 18,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Q${index + 1}. ${question.question}',
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                if (result != null)
+                  Row(
+                    children: [
+                      _AnswerChip(
+                        label: '내 답변',
+                        value: result!.submittedAnswer,
+                        isCorrect: isCorrect,
+                      ),
+                      const SizedBox(width: 8),
+                      if (!isCorrect)
+                        _AnswerChip(
+                          label: '정답',
+                          value: result!.correctAnswer,
+                          isCorrect: true,
+                          isAnswer: true,
+                        ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AnswerChip extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool isCorrect;
+  final bool isAnswer;
+
+  const _AnswerChip({
+    required this.label,
+    required this.value,
+    required this.isCorrect,
+    this.isAnswer = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isCorrect ? Colors.green : Colors.red;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withOpacity(0.3)),
+      ),
+      child: Text(
+        '$label: $value',
+        style: TextStyle(
+          fontSize: 12,
+          color: color[700],
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+// ── 일일 제한 초과 뷰 ────────────────────────────────────────
+class _DailyLimitView extends StatelessWidget {
+  final String message;
+  final VoidCallback onClose;
+
+  const _DailyLimitView({required this.message, required this.onClose});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 80,
+              height: 80,
+              decoration: BoxDecoration(
+                color: Colors.orange[50],
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.hourglass_empty,
+                size: 40,
+                color: Colors.orange[600],
+              ),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              '오늘 응시 횟수 초과',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 15, color: Colors.grey[600], height: 1.5),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '내일 자정 이후 다시 도전할 수 있습니다.',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 13, color: Colors.grey[500]),
+            ),
+            const SizedBox(height: 32),
+            OutlinedButton(
+              onPressed: onClose,
+              style: OutlinedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 32, vertical: 14),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12)),
+              ),
+              child: const Text('닫기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pentalk_front/lib/screens/session_detail_screen.dart
+++ b/pentalk_front/lib/screens/session_detail_screen.dart
@@ -13,6 +13,8 @@ import '../services/auth_service.dart';
 import '../services/local_material_service.dart';
 import '../models/student_session_model.dart';
 import 'drawing_screen.dart'; // 👈 추가
+import '../widgets/quiz_editor_widget.dart';
+
 
 class SessionDetailScreen extends StatefulWidget {
   final String sessionId;
@@ -424,21 +426,25 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                     ],
                   ),
                 )
-                    : ListView.builder(
-                  padding: const EdgeInsets.symmetric(vertical: 8),
-                  itemCount: materialProvider.materials.length,
-                  itemBuilder: (context, index) {
-                    final material = materialProvider.materials[index];
-                    return _MaterialListItem(
-                      material: material,
-                      onOpen: () => _navigateToDrawing(
-                        context,
+                    : ListView(
+                  padding: const EdgeInsets.only(top: 8, bottom: 100),
+                  children: [
+                    ...materialProvider.materials.map(
+                          (material) => _MaterialListItem(
                         material: material,
-                        connectRealtime: _canUseRemoteMaterials,
+                        onOpen: () => _navigateToDrawing(
+                          context,
+                          material: material,
+                          connectRealtime: _canUseRemoteMaterials,
+                        ),
+                        onDelete: () => _handleFileDelete(material.id),
                       ),
-                      onDelete: () => _handleFileDelete(material.id),
-                    );
-                  },
+                    ),
+                    const SizedBox(height: 16),
+                    const Divider(thickness: 1),
+                    if (widget.sessionId != 'local-pdf-workspace')
+                      QuizEditorWidget(sessionId: widget.sessionId),
+                  ],
                 ),
               ),
             ],

--- a/pentalk_front/lib/services/api_service.dart
+++ b/pentalk_front/lib/services/api_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import '../config/app_config.dart';
 import '../models/drawing_models.dart';
 import 'auth_service.dart';
+import '../models/quiz_model.dart';
 
 /// ===============================
 /// REST API 클라이언트 서비스
@@ -80,6 +81,7 @@ class ApiService {
         message: e.toString(),
       );
     }
+
   }
 
   /// ===============================
@@ -799,6 +801,178 @@ class ApiService {
 
     final argb = hex.length == 6 ? 'FF$hex' : hex;
     return '#${argb.toUpperCase()}';
+  }
+  // ── 퀴즈 문항 조회 (학생 + 교사 공용) ─────────────────────
+//
+// GET /sessions/:sessionId/quiz
+// 응답: { ok: true, questions: [...] }
+//
+// 반환: List<QuizQuestion>
+// 교사 응답에는 answer 포함, 학생 응답에는 answer null
+//
+  static Future<List<QuizQuestion>> getQuizQuestions({
+    required String sessionId,
+  }) async {
+    final token = await AuthService.getToken();
+    final uri = Uri.parse('${AppConfig.apiBaseUrl}/sessions/$sessionId/quiz');
+
+    final response = await http.get(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      final rawQuestions = body['questions'] as List<dynamic>? ?? [];
+      return rawQuestions
+          .whereType<Map>()
+          .map((q) => QuizQuestion.fromJson(Map<String, dynamic>.from(q)))
+          .toList();
+    }
+
+    throw Exception('퀴즈 조회 실패 [${response.statusCode}]');
+  }
+
+// ── 퀴즈 답안 제출 (학생) ─────────────────────────────────
+//
+// POST /sessions/:sessionId/quiz/submit
+// Body: { questionId, answer }
+// 응답: { ok, questionId, isCorrect, submittedAnswer, correctAnswer }
+// 429: QUIZ_DAILY_LIMIT_EXCEEDED
+//
+  static Future<QuizSubmitResult> submitQuizAnswer({
+    required String sessionId,
+    required String questionId,
+    required String answer,
+  }) async {
+    final token = await AuthService.getToken();
+    final uri = Uri.parse(
+        '${AppConfig.apiBaseUrl}/sessions/$sessionId/quiz/submit');
+
+    final response = await http.post(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({'questionId': questionId, 'answer': answer}),
+    );
+
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      return QuizSubmitResult.fromJson(body);
+    }
+
+    if (response.statusCode == 429) {
+      // 하루 2회 초과
+      throw const QuizDailyLimitException();
+    }
+
+    throw Exception('퀴즈 제출 실패 [${response.statusCode}]');
+  }
+
+// ── 퀴즈 문항 추가 (교사) ─────────────────────────────────
+//
+// POST /sessions/:sessionId/quiz
+// Body: { question, answer, order }
+// 응답: { ok: true, question: { id, question, answer, order, createdAt } }
+//
+  static Future<QuizQuestion> addQuizQuestion({
+    required String sessionId,
+    required String question,
+    required String answer,
+    required int order,
+  }) async {
+    final token = await AuthService.getToken();
+    final uri = Uri.parse('${AppConfig.apiBaseUrl}/sessions/$sessionId/quiz');
+
+    final response = await http.post(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({
+        'question': question,
+        'answer': answer,
+        'order': order,
+      }),
+    );
+
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      final rawQuestion = body['question'] as Map<String, dynamic>;
+      return QuizQuestion.fromJson(rawQuestion);
+    }
+
+    throw Exception('문항 추가 실패 [${response.statusCode}]');
+  }
+
+// ── 퀴즈 문항 수정 (교사) ─────────────────────────────────
+//
+// PUT /sessions/:sessionId/quiz/:questionId
+// Body: { question?, answer? }
+//
+  static Future<QuizQuestion> updateQuizQuestion({
+    required String sessionId,
+    required String questionId,
+    String? question,
+    String? answer,
+  }) async {
+    assert(question != null || answer != null,
+    'question 또는 answer 중 하나는 필수입니다');
+
+    final token = await AuthService.getToken();
+    final uri = Uri.parse(
+        '${AppConfig.apiBaseUrl}/sessions/$sessionId/quiz/$questionId');
+
+    final body = <String, dynamic>{};
+    if (question != null) body['question'] = question;
+    if (answer != null) body['answer'] = answer;
+
+    final response = await http.put(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode(body),
+    );
+
+    if (response.statusCode == 200) {
+      final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+      final rawQuestion = responseBody['question'] as Map<String, dynamic>;
+      return QuizQuestion.fromJson(rawQuestion);
+    }
+
+    throw Exception('문항 수정 실패 [${response.statusCode}]');
+  }
+
+// ── 퀴즈 문항 삭제 (교사) ─────────────────────────────────
+//
+// DELETE /sessions/:sessionId/quiz/:questionId
+//
+  static Future<void> deleteQuizQuestion({
+    required String sessionId,
+    required String questionId,
+  }) async {
+    final token = await AuthService.getToken();
+    final uri = Uri.parse(
+        '${AppConfig.apiBaseUrl}/sessions/$sessionId/quiz/$questionId');
+
+    final response = await http.delete(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode != 200 && response.statusCode != 204) {
+      throw Exception('문항 삭제 실패 [${response.statusCode}]');
+    }
   }
 }
 

--- a/pentalk_front/lib/widgets/quiz_editor_widget.dart
+++ b/pentalk_front/lib/widgets/quiz_editor_widget.dart
@@ -1,0 +1,566 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/quiz_model.dart';
+import '../providers/quiz_provider.dart';
+
+/// ===============================
+/// 교사용 복습 퀴즈 관리 위젯
+/// SessionDetailScreen 내에 삽입해서 사용
+///
+/// 사용 예:
+///   QuizEditorWidget(sessionId: session.id)
+/// ===============================
+class QuizEditorWidget extends StatefulWidget {
+  final String sessionId;
+
+  const QuizEditorWidget({Key? key, required this.sessionId}) : super(key: key);
+
+  @override
+  State<QuizEditorWidget> createState() => _QuizEditorWidgetState();
+}
+
+class _QuizEditorWidgetState extends State<QuizEditorWidget> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context
+          .read<QuizProvider>()
+          .loadQuestionsForTeacher(widget.sessionId);
+    });
+  }
+
+  void _showAddDialog() {
+    _showQuestionDialog(
+      title: '문항 추가',
+      onSave: (question, answer) async {
+        await context.read<QuizProvider>().addQuestion(
+          widget.sessionId,
+          question: question,
+          answer: answer,
+        );
+      },
+    );
+  }
+
+  void _showEditDialog(QuizQuestion existing) {
+    _showQuestionDialog(
+      title: '문항 수정',
+      initialQuestion: existing.question,
+      initialAnswer: existing.answer,
+      onSave: (question, answer) async {
+        await context.read<QuizProvider>().updateQuestion(
+          widget.sessionId,
+          existing.id,
+          question: question,
+          answer: answer,
+        );
+      },
+    );
+  }
+
+  void _showQuestionDialog({
+    required String title,
+    String? initialQuestion,
+    String? initialAnswer,
+    required Future<void> Function(String question, String answer) onSave,
+  }) {
+    showDialog(
+      context: context,
+      builder: (_) => _QuestionEditDialog(
+        title: title,
+        initialQuestion: initialQuestion ?? '',
+        initialAnswer: initialAnswer ?? 'O',
+        onSave: (question, answer) async {
+          try {
+            await onSave(question, answer);
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('저장됐습니다')),
+              );
+            }
+          } catch (e) {
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('오류: $e'),
+                  backgroundColor: Colors.red,
+                ),
+              );
+            }
+          }
+        },
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(QuizQuestion q) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        shape:
+        RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: const Text('문항 삭제'),
+        content: Text('Q${q.order}. "${q.question}" 을 삭제하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('취소'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            style:
+            ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            child: const Text('삭제'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && context.mounted) {
+      try {
+        await context
+            .read<QuizProvider>()
+            .deleteQuestion(widget.sessionId, q.id);
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('삭제됐습니다')),
+          );
+        }
+      } catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('삭제 실패: $e'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<QuizProvider>(
+      builder: (context, provider, _) {
+        final questions = provider.questions;
+        final isLoading = provider.status == QuizStatus.loading;
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 섹션 헤더
+            Padding(
+              padding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  const Icon(Icons.quiz_outlined,
+                      size: 22, color: Colors.blue),
+                  const SizedBox(width: 8),
+                  const Text(
+                    '복습 퀴즈',
+                    style: TextStyle(
+                        fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  const Spacer(),
+                  // 문항 수 뱃지
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 10, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: questions.length >= 3
+                          ? Colors.grey[200]
+                          : Colors.blue[50],
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Text(
+                      '${questions.length} / 3',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.bold,
+                        color: questions.length >= 3
+                            ? Colors.grey[600]
+                            : Colors.blue[700],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  // 추가 버튼
+                  if (provider.canAddQuestion)
+                    IconButton(
+                      icon: const Icon(Icons.add_circle_outline),
+                      color: Colors.blue,
+                      tooltip: '문항 추가',
+                      onPressed: _showAddDialog,
+                    ),
+                ],
+              ),
+            ),
+
+            const Divider(height: 1),
+
+            // 로딩
+            if (isLoading)
+              const Padding(
+                padding: EdgeInsets.all(24),
+                child: Center(child: CircularProgressIndicator()),
+              )
+            // 문항 없음
+            else if (questions.isEmpty)
+              _EmptyQuizHint(onAdd: _showAddDialog)
+            // 문항 목록
+            else
+              ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: questions.length,
+                separatorBuilder: (_, __) =>
+                const Divider(height: 1, indent: 16, endIndent: 16),
+                itemBuilder: (_, index) {
+                  final q = questions[index];
+                  return _QuestionTile(
+                    question: q,
+                    onEdit: () => _showEditDialog(q),
+                    onDelete: () => _confirmDelete(q),
+                  );
+                },
+              ),
+
+            if (questions.isNotEmpty && provider.canAddQuestion)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                child: OutlinedButton.icon(
+                  onPressed: _showAddDialog,
+                  icon: const Icon(Icons.add, size: 18),
+                  label: const Text('문항 추가'),
+                  style: OutlinedButton.styleFrom(
+                    minimumSize: const Size(double.infinity, 44),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10)),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+// ── 빈 상태 힌트 ──────────────────────────────────────────────
+class _EmptyQuizHint extends StatelessWidget {
+  final VoidCallback onAdd;
+
+  const _EmptyQuizHint({required this.onAdd});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        children: [
+          Icon(Icons.quiz_outlined, size: 48, color: Colors.grey[400]),
+          const SizedBox(height: 12),
+          Text(
+            '아직 등록된 문항이 없습니다',
+            style: TextStyle(fontSize: 15, color: Colors.grey[600]),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '수업 종료 후 학생이 PDF를 받으려면\n퀴즈를 통과해야 합니다 (최대 3문항)',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 13, color: Colors.grey[500]),
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton.icon(
+            onPressed: onAdd,
+            icon: const Icon(Icons.add, size: 18),
+            label: const Text('첫 문항 추가'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── 문항 타일 ─────────────────────────────────────────────────
+class _QuestionTile extends StatelessWidget {
+  final QuizQuestion question;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  const _QuestionTile({
+    required this.question,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final answer = question.answer ?? '?';
+    final answerColor = answer == 'O' ? Colors.green : Colors.red;
+
+    return ListTile(
+      contentPadding:
+      const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      leading: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: Colors.blue[50],
+          shape: BoxShape.circle,
+        ),
+        child: Center(
+          child: Text(
+            '${question.order}',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Colors.blue[700],
+            ),
+          ),
+        ),
+      ),
+      title: Text(
+        question.question,
+        style: const TextStyle(fontSize: 15),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Row(
+          children: [
+            Container(
+              padding:
+              const EdgeInsets.symmetric(horizontal: 10, vertical: 3),
+              decoration: BoxDecoration(
+                color: answerColor.withOpacity(0.12),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: answerColor.withOpacity(0.4)),
+              ),
+              child: Text(
+                '정답: $answer',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: answerColor[700],
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.edit_outlined, size: 20),
+            color: Colors.grey[600],
+            onPressed: onEdit,
+            tooltip: '수정',
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline, size: 20),
+            color: Colors.red[400],
+            onPressed: onDelete,
+            tooltip: '삭제',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── 문항 추가/수정 다이얼로그 ────────────────────────────────
+class _QuestionEditDialog extends StatefulWidget {
+  final String title;
+  final String initialQuestion;
+  final String initialAnswer;
+  final Future<void> Function(String question, String answer) onSave;
+
+  const _QuestionEditDialog({
+    required this.title,
+    required this.initialQuestion,
+    required this.initialAnswer,
+    required this.onSave,
+  });
+
+  @override
+  State<_QuestionEditDialog> createState() => _QuestionEditDialogState();
+}
+
+class _QuestionEditDialogState extends State<_QuestionEditDialog> {
+  late final TextEditingController _questionController;
+  late String _selectedAnswer;
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _questionController =
+        TextEditingController(text: widget.initialQuestion);
+    _selectedAnswer =
+    (widget.initialAnswer == 'X') ? 'X' : 'O';
+  }
+
+  @override
+  void dispose() {
+    _questionController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleSave() async {
+    final question = _questionController.text.trim();
+    if (question.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('문항 내용을 입력해주세요')),
+      );
+      return;
+    }
+
+    setState(() => _isSaving = true);
+    try {
+      await widget.onSave(question, _selectedAnswer);
+      if (context.mounted) Navigator.pop(context);
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+              content: Text('저장 실패: $e'),
+              backgroundColor: Colors.red),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isSaving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape:
+      RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      title: Text(widget.title),
+      contentPadding: const EdgeInsets.fromLTRB(24, 16, 24, 0),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 문항 입력
+          TextField(
+            controller: _questionController,
+            decoration: InputDecoration(
+              labelText: '문항 내용',
+              hintText: '예: 광합성은 빛에너지를 이용해 포도당을 만든다.',
+              border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            maxLines: 3,
+            minLines: 2,
+            textInputAction: TextInputAction.done,
+          ),
+          const SizedBox(height: 20),
+
+          // 정답 선택
+          const Text(
+            '정답',
+            style:
+            TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(
+                child: _OxSelectButton(
+                  label: 'O',
+                  isSelected: _selectedAnswer == 'O',
+                  color: Colors.green,
+                  onTap: () => setState(() => _selectedAnswer = 'O'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _OxSelectButton(
+                  label: 'X',
+                  isSelected: _selectedAnswer == 'X',
+                  color: Colors.red,
+                  onTap: () => setState(() => _selectedAnswer = 'X'),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+      actionsPadding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      actions: [
+        TextButton(
+          onPressed: _isSaving ? null : () => Navigator.pop(context),
+          child: const Text('취소'),
+        ),
+        ElevatedButton(
+          onPressed: _isSaving ? null : _handleSave,
+          style: ElevatedButton.styleFrom(
+            padding:
+            const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10)),
+          ),
+          child: _isSaving
+              ? const SizedBox(
+            width: 18,
+            height: 18,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          )
+              : const Text('저장'),
+        ),
+      ],
+    );
+  }
+}
+
+class _OxSelectButton extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final Color color;
+  final VoidCallback onTap;
+
+  const _OxSelectButton({
+    required this.label,
+    required this.isSelected,
+    required this.color,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 160),
+      height: 52,
+      decoration: BoxDecoration(
+        color: isSelected ? color.withOpacity(0.12) : Colors.grey[50],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isSelected ? color : Colors.grey[300]!,
+          width: isSelected ? 2.5 : 1,
+        ),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Center(
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+              color: isSelected ? color : Colors.grey[400],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 복습 퀴즈 (Review Quiz)

세션 종료 후 학생이 퀴즈를 통과해야 PDF를 받을 수 있는 기능을 구현

### 주요 흐름
- 교사가 세션 상세 화면에서 OX 퀴즈 최대 3문항 등록/수정/삭제
- 세션 종료 시 학생에게 퀴즈 화면 자동 표시
- 3문제 중 2문제 이상(60%) 정답 시 PDF 다운로드 활성화
- 하루 최대 2회 응시 제한 (서버 429 응답 처리)

### 추가된 파일
- `lib/models/quiz_model.dart` — QuizQuestion, QuizSubmitResult, QuizStatus 모델
- `lib/providers/quiz_provider.dart` — 학생 수행 / 교사 관리 상태 관리
- `lib/screens/quiz_screen.dart` — 학생용 OX 퀴즈 전체 화면
- `lib/widgets/quiz_editor_widget.dart` — 교사용 퀴즈 등록/수정/삭제 위젯

### 수정된 파일
- `lib/main.dart` — QuizProvider MultiProvider 등록
- `lib/services/api_service.dart` — 퀴즈 관련 API 메서드 5개 추가
  - GET /sessions/:id/quiz
  - POST /sessions/:id/quiz
  - PUT /sessions/:id/quiz/:questionId
  - DELETE /sessions/:id/quiz/:questionId
  - POST /sessions/:id/quiz/submit
- `lib/screens/drawing_screen.dart` — session:ended 시 퀴즈 화면 트리거 연결
- `lib/screens/session_detail_screen.dart` — 교사 화면 하단 퀴즈 관리 섹션 추가

### 예외 처리
- 429 응답 → QuizDailyLimitException → "내일 다시 도전" 안내 화면
- 퀴즈 미등록 시 → noQuestions 상태 → PDF 바로 다운로드 가능
- 미통과 시 → 남은 일일 횟수 내 재시도 가능