### PR TITLE
Feat: 이해도 체크 payload 수정 및 복습 퀴즈 버그 수정

### DIFF
--- a/pentalk_front/lib/screens/drawing_screen.dart
+++ b/pentalk_front/lib/screens/drawing_screen.dart
@@ -384,8 +384,11 @@ class _DrawingScreenState extends State<DrawingScreen> {
   /// ===============================
   void _handleEndPoll() {
     final pollState = context.read<PollProvider>().state;
-    if (pollState.pollData == null) return;
-
+    debugPrint('handleEndPoll: pollData=${pollState.pollData?.pollId}');
+    if (pollState.pollData == null) {
+      debugPrint('pollData is null, cannot end poll');
+      return;
+    }
     _drawingProvider.socketService.sendPollEnd(pollState.pollData!.pollId);
   }
 
@@ -840,6 +843,21 @@ class _DrawingScreenState extends State<DrawingScreen> {
 
               // 교사용 컨트롤
               if (widget.isTeacher) ...[
+                // 교사 전용: 이해도 체크 버튼
+                Consumer<PollProvider>(
+                  builder: (context, pollProvider, _) {
+                    final isActive = pollProvider.state.isActive;
+                    return IconButton(
+                      icon: Icon(
+                        isActive ? Icons.poll : Icons.poll_outlined,
+                        color: isActive ? Colors.amber : Colors.black87,
+                      ),
+                      onPressed: isActive ? _handleEndPoll : _handleStartPoll,
+                      tooltip: isActive ? '이해도 체크 종료' : '이해도 체크 시작',
+                    );
+                  },
+                ),
+
                 if (_shareableSessionId != null)
                   IconButton(
                     icon: const Icon(Icons.qr_code_2),
@@ -857,20 +875,6 @@ class _DrawingScreenState extends State<DrawingScreen> {
                   tooltip: '전체 지우기',
                 ),
 
-                // 교사 전용: 이해도 체크 버튼
-                Consumer<PollProvider>(
-                  builder: (context, pollProvider, _) {
-                    final isActive = pollProvider.state.isActive;
-                    return IconButton(
-                      icon: Icon(
-                        isActive ? Icons.poll : Icons.poll_outlined,
-                        color: isActive ? Colors.amber : Colors.white,
-                      ),
-                      onPressed: isActive ? _handleEndPoll : _handleStartPoll,
-                      tooltip: isActive ? '이해도 체크 종료' : '이해도 체크 시작',
-                    );
-                  },
-                ),
               ],
 
               if (!widget.isTeacher) ...[

--- a/pentalk_front/lib/screens/session_detail_screen.dart
+++ b/pentalk_front/lib/screens/session_detail_screen.dart
@@ -120,6 +120,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
       final response = await ApiService.createSession(
         classId: classId,
         materialId: material.id,
+        title: material.title,
       );
       if (!response.success || response.data == null) {
         throw Exception(response.message ?? '실시간 세션 생성에 실패했습니다.');
@@ -460,9 +461,11 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                             if (footerIndex == 1) {
                               return const Divider(thickness: 1);
                             }
-                            return QuizEditorWidget(
-                              sessionId: widget.sessionId,
-                            );
+                            if (_looksLikeRealtimeSessionId(widget.sessionId))
+                              return QuizEditorWidget(
+                                sessionId: widget.sessionId,
+                              );
+                            return const SizedBox.shrink();
                           }
                           final material = materialProvider.materials[index];
                           return _MaterialListItem(

--- a/pentalk_front/lib/services/api_service.dart
+++ b/pentalk_front/lib/services/api_service.dart
@@ -962,6 +962,11 @@ class ApiService {
           .toList();
     }
 
+    // 404 = 아직 등록된 문항 없음 → 빈 리스트 반환
+    if (response.statusCode == 404) {
+      return [];
+    }
+
     throw Exception('퀴즈 조회 실패 [${response.statusCode}]');
   }
 

--- a/pentalk_front/lib/services/socket_service.dart
+++ b/pentalk_front/lib/services/socket_service.dart
@@ -390,16 +390,25 @@ class SocketService {
     }, summary: 'poll:answer pollId=$pollId');
   }
 
-  void sendPollStart({required String question,
-    required List<Map<String, dynamic>> options, int? duration}) {
-    final optionTexts = options
-        .map((option) => option['text']?.toString() ?? '')
-        .where((text) => text.isNotEmpty)
+  void sendPollStart({
+    required String question,
+    required List<Map<String, dynamic>> options,
+    int? duration,
+  }) {
+    final formattedOptions = options
+        .asMap()
+        .entries
+        .map((entry) => {
+      'id': (entry.key + 1).toString(),
+      'text': entry.value['text']?.toString() ?? '',
+    })
+        .where((o) => (o['text'] as String).isNotEmpty)
         .toList();
+
     _emitOrQueue('poll:start', {
       'question': question,
-      'options': optionTexts,
-      if (duration != null) 'duration': duration,
+      'options': formattedOptions,
+      if (duration != null) 'duration': duration.toInt(),
     }, summary: 'poll:start');
   }
 

--- a/pentalk_front/lib/widgets/quiz_editor_widget.dart
+++ b/pentalk_front/lib/widgets/quiz_editor_widget.dart
@@ -444,7 +444,7 @@ class _QuestionEditDialogState extends State<_QuestionEditDialog> {
       RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       title: Text(widget.title),
       contentPadding: const EdgeInsets.fromLTRB(24, 16, 24, 0),
-      content: Column(
+        content: SingleChildScrollView(child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -493,6 +493,7 @@ class _QuestionEditDialogState extends State<_QuestionEditDialog> {
           ),
           const SizedBox(height: 8),
         ],
+        )
       ),
       actionsPadding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
       actions: [


### PR DESCRIPTION
## 변경 사항

### 이해도 체크
- poll:start payload 형식 수정 (options label → text, duration int 변환)
- 이해도 체크 버튼 AppBar 앞쪽으로 위치 조정
- 이해도 체크 버튼 색상 수정 (흰색 → 검은색)

### 복습 퀴즈 버그 수정
- 퀴즈 조회 404를 빈 리스트로 처리
- 복습 퀴즈 다이얼로그 overflow 수정 (SingleChildScrollView 추가)
- UUID 형식 세션일 때만 QuizEditorWidget 표시