### PR TITLE
Feat: 판서 정확성 개선 (베지어 곡선 cubic 변환, 샘플링 간격 축소)

### DIFF
--- a/pentalk_front/lib/drawing_streamer.dart
+++ b/pentalk_front/lib/drawing_streamer.dart
@@ -28,9 +28,9 @@ class DrawPoint {
 class DrawStreamScheduler {
   DrawStreamScheduler({
     required this.sender,
-    this.sampleInterval = const Duration(milliseconds: 16),
-    this.sendInterval = const Duration(milliseconds: 32),
-    this.distanceThreshold = 0.5,
+    this.sampleInterval = const Duration(milliseconds: 8),
+    this.sendInterval = const Duration(milliseconds: 16),
+    this.distanceThreshold = 0.3,
   });
 
   final Future<void> Function(Map<String, dynamic> payload) sender;

--- a/pentalk_front/lib/widgets/drawing_painter.dart
+++ b/pentalk_front/lib/widgets/drawing_painter.dart
@@ -61,19 +61,44 @@ class DrawingPainter extends CustomPainter {
       final p1 = scaler.normalizedToPixel(points[i + 1]);
       final p2 = scaler.normalizedToPixel(points[i + 2]);
 
+      // 꺾임 각도에 따라 tension 조절 (adaptive tension)
+      final tension = _calcTension(p0, p1, p2);
+
       final cp1 = Offset(
         p0.dx + (p1.dx - p0.dx) * 0.5,
         p0.dy + (p1.dy - p0.dy) * 0.5,
       );
       final cp2 = Offset(
-        p1.dx - (p2.dx - p0.dx) * 0.15,
-        p1.dy - (p2.dy - p0.dy) * 0.15,
+        p1.dx - (p2.dx - p0.dx) * tension,
+        p1.dy - (p2.dy - p0.dy) * tension,
       );
 
       path.cubicTo(cp1.dx, cp1.dy, cp2.dx, cp2.dy, p1.dx, p1.dy);
     }
 
+    // 마지막 점 연결 (기존 누락 버그 수정)
+    if (points.length >= 2) {
+      final last = scaler.normalizedToPixel(points.last);
+      path.lineTo(last.dx, last.dy);
+    }
+
     return path;
+  }
+
+  // 꺾임 각도 기반 tension 계산
+  double _calcTension(Offset p0, Offset p1, Offset p2) {
+    final v1 = p1 - p0;
+    final v2 = p2 - p1;
+    final len1 = v1.distance;
+    final len2 = v2.distance;
+    if (len1 < 0.001 || len2 < 0.001) return 0.15;
+
+    // cosAngle: 1=직선, 0=직각, -1=U턴
+    final cosAngle = (v1.dx * v2.dx + v1.dy * v2.dy) / (len1 * len2);
+
+    // 약 81° 이상 꺾임이면 tension 제거 → 날카로운 모서리 유지
+    if (cosAngle < 0.15) return 0.0;
+    return 0.15;
   }
 
   @override

--- a/pentalk_front/lib/widgets/drawing_painter.dart
+++ b/pentalk_front/lib/widgets/drawing_painter.dart
@@ -53,35 +53,25 @@ class DrawingPainter extends CustomPainter {
     final path = Path();
     if (points.isEmpty) return path;
 
-    final firstPoint = scaler.normalizedToPixel(points[0]);
-    path.moveTo(firstPoint.dx, firstPoint.dy);
+    final first = scaler.normalizedToPixel(points[0]);
+    path.moveTo(first.dx, first.dy);
 
-    if (points.length == 2) {
-      final secondPoint = scaler.normalizedToPixel(points[1]);
-      path.lineTo(secondPoint.dx, secondPoint.dy);
-      return path;
-    }
+    for (int i = 0; i < points.length - 2; i++) {
+      final p0 = scaler.normalizedToPixel(points[i]);
+      final p1 = scaler.normalizedToPixel(points[i + 1]);
+      final p2 = scaler.normalizedToPixel(points[i + 2]);
 
-    for (int i = 0; i < points.length - 1; i++) {
-      final current = scaler.normalizedToPixel(points[i]);
-      final next = scaler.normalizedToPixel(points[i + 1]);
-
-      final controlPoint = current;
-      final endPoint = Offset(
-        (current.dx + next.dx) / 2,
-        (current.dy + next.dy) / 2,
+      final cp1 = Offset(
+        p0.dx + (p1.dx - p0.dx) * 0.5,
+        p0.dy + (p1.dy - p0.dy) * 0.5,
+      );
+      final cp2 = Offset(
+        p1.dx - (p2.dx - p0.dx) * 0.15,
+        p1.dy - (p2.dy - p0.dy) * 0.15,
       );
 
-      path.quadraticBezierTo(
-        controlPoint.dx,
-        controlPoint.dy,
-        endPoint.dx,
-        endPoint.dy,
-      );
+      path.cubicTo(cp1.dx, cp1.dy, cp2.dx, cp2.dy, p1.dx, p1.dy);
     }
-
-    final lastPoint = scaler.normalizedToPixel(points.last);
-    path.lineTo(lastPoint.dx, lastPoint.dy);
 
     return path;
   }


### PR DESCRIPTION
## 변경 사항

### 판서 정확성 개선
- drawing_painter.dart: quadratic bezier → cubic bezier 변환으로 곡선 부드럽게 개선
- drawing_streamer.dart: 샘플링 간격 축소 (16ms → 8ms, 32ms → 16ms)
- drawing_streamer.dart: 거리 임계값 축소 (0.5 → 0.3)으로 포인트 수집 밀도 향상