### PR TITLE
[Feat]: PDF 추출 흐름 수정 및 세션-자료 연결 버그 수정

### DIFF
--- a/pentalk_front/lib/screens/drawing_screen.dart
+++ b/pentalk_front/lib/screens/drawing_screen.dart
@@ -27,7 +27,6 @@ import '../services/deep_link_service.dart';
 import '../services/pdf_document_service.dart';
 import '../services/pdf_export_service.dart';
 import '../services/pdf_file_service.dart';
-import '../screens/quiz_screen.dart';
 import 'student_home_screen.dart';
 import 'teacher_home_screen.dart';
 
@@ -505,16 +504,9 @@ class _DrawingScreenState extends State<DrawingScreen> {
       SessionEndedDialog.showStudentNotification(
         context,
         message: message,
-        onConfirm: () {
-          QuizScreen.show(
-            context,
-            sessionId: widget.sessionId ?? widget.roomId ?? '',
-            onPassed: () {
-              _handleExportPdf();
-              _cleanupAndGoHome();
-            },
-            onClose: _cleanupAndGoHome,
-          );
+        onConfirm: () async {
+          await _handleExportPdf();
+          if (mounted) _cleanupAndGoHome();
         },
       );
     }

--- a/pentalk_front/lib/screens/session_detail_screen.dart
+++ b/pentalk_front/lib/screens/session_detail_screen.dart
@@ -71,10 +71,13 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
     final userId = await AuthService.getUserId() ?? 'teacher';
     final resolvedBackgroundUrl = await _resolveMaterialBackgroundUrl(material);
     String? realtimeSessionId = connectRealtime ? _effectiveSessionId : null;
+    debugPrint('🎯 _navigateToDrawing: effectiveSessionId=$_effectiveSessionId, realtimeSessionId=$realtimeSessionId');
     if (connectRealtime && realtimeSessionId == null) {
+      debugPrint('🆕 Creating new session in _navigateToDrawing...');
       realtimeSessionId = await _createRealtimeSessionForMaterial(material);
       if (realtimeSessionId == null) return;
     }
+    debugPrint('🚀 Opening DrawingScreen with sessionId=$realtimeSessionId');
     if (!context.mounted) return;
     Navigator.push(
       context,
@@ -244,6 +247,27 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
 
       setState(() => _isUploading = true);
 
+      debugPrint('📋 _handleFileUpload: '
+          'widgetSessionId=${widget.sessionId}, '
+          'canUseRemote=$_canUseRemoteMaterials');
+
+      // 자료 업로드 전에 항상 새 세션 생성 (세션-자료 연결 보장)
+      if (_canUseRemoteMaterials) {
+        debugPrint('🆕 Creating new session before material upload...');
+        final sessionResponse = await ApiService.createSession(
+          classId: widget.classId!,
+        );
+        if (sessionResponse.success && sessionResponse.data != null) {
+          setState(() {
+            _realtimeSessionId = sessionResponse.data!.sessionId;
+          });
+          debugPrint('✅ New session created: $_realtimeSessionId');
+        } else {
+          debugPrint('❌ Session creation failed: ${sessionResponse.message}');
+        }
+      }
+
+      debugPrint('📤 Uploading material with sessionId=$_effectiveSessionId');
       final material = await _createMaterialForTesting(filePath: file.path);
       if (!mounted) return;
 
@@ -289,9 +313,11 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
     }
 
     final file = await _localMaterialService.importPdf(File(filePath));
+    final resolvedSessionId = _effectiveSessionId ?? widget.sessionId;
+    debugPrint('🔗 uploadMaterial: classId=$classId, sessionId=$resolvedSessionId');
     final uploaded = await ApiService.uploadMaterial(
       classId: classId,
-      sessionId: _effectiveSessionId ?? widget.sessionId,
+      sessionId: resolvedSessionId,
       filePath: file.url,
       fileName: file.fileName,
     );


### PR DESCRIPTION
### 변경 사항
## 1. 복습 퀴즈 게이팅 제거 (drawing_screen.dart)
수업 종료 시 QuizScreen을 거치지 않고 바로 PDF 추출로 이동하도록 변경
데모 환경에서 미완성 퀴즈 기능으로 인해 PDF 추출이 막히는 문제 해결
## 2. 세션-자료 연결 버그 수정 (session_detail_screen.dart)
PDF 업로드 전에 항상 새 세션을 먼저 생성하도록 변경
기존 세션 ID(이미 종료된 세션)로 자료를 업로드하면 서버에서 세션-자료 연결이 안 되어 MATERIAL_NOT_FOUND 400 에러가 발생하던 문제 수정
## 3. PDF 추출 완료 후 화면 이동 (drawing_screen.dart)
_handleExportPdf()를 await 없이 호출해서 추출이 끝나기 전에 홈 화면으로 이동해버리는 버그 수정
await _handleExportPdf() 완료 후 _cleanupAndGoHome() 실행하도록 변경
저장 완료 다이얼로그가 제대로 표시되지 않던 문제 해결
## 관련 이슈
MATERIAL_NOT_FOUND 400 해결
NOT_SESSION_MEMBER 403 → 서버팀 수정 (export 권한 체크를 ClassMember → 소켓 세션 참여자 기반으로 변경)
PDF_EXPORT_FAILED 500 → 서버팀 수정