### PR TITLE
세션 생성 시 capacity/password 누락으로 인한 퀴즈 세션 불일치 문제 수정

### DIFF
--- a/pentalk_front/lib/screens/material_detail_screen.dart
+++ b/pentalk_front/lib/screens/material_detail_screen.dart
@@ -287,6 +287,8 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
       final response = await ApiService.createSession(
         classId: widget.classId!.trim(),
         materialId: widget.material.id,
+        maxParticipants: 30,
+        password: '0000',
       );
 
       if (!response.success || response.data == null) {

--- a/pentalk_front/lib/screens/session_detail_screen.dart
+++ b/pentalk_front/lib/screens/session_detail_screen.dart
@@ -20,6 +20,7 @@ class SessionDetailScreen extends StatefulWidget {
   final String? classId; // 자료 업로드에 필요
   final bool localOnly;
   final String? titleOverride;
+  final String? password; // 교사가 세션 생성 시 설정한 비밀번호
 
   const SessionDetailScreen({
     Key? key,
@@ -27,6 +28,7 @@ class SessionDetailScreen extends StatefulWidget {
     this.classId,
     this.localOnly = false,
     this.titleOverride,
+    this.password,
   }) : super(key: key);
 
   @override
@@ -124,6 +126,8 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
         classId: classId,
         materialId: material.id,
         title: material.title,
+        maxParticipants: 30,
+        password: widget.password ?? '0000',
       );
       if (!response.success || response.data == null) {
         throw Exception(response.message ?? '실시간 세션 생성에 실패했습니다.');
@@ -254,8 +258,12 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
       // 자료 업로드 전에 항상 새 세션 생성 (세션-자료 연결 보장)
       if (_canUseRemoteMaterials) {
         debugPrint('🆕 Creating new session before material upload...');
+        final fileNameForTitle = file.path.split(RegExp(r'[\\/]')).last;
         final sessionResponse = await ApiService.createSession(
           classId: widget.classId!,
+          title: fileNameForTitle,
+          maxParticipants: 30,
+          password: widget.password ?? '0000',
         );
         if (sessionResponse.success && sessionResponse.data != null) {
           setState(() {
@@ -487,9 +495,12 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                             if (footerIndex == 1) {
                               return const Divider(thickness: 1);
                             }
-                            if (_looksLikeRealtimeSessionId(widget.sessionId))
+                            final quizSessionId =
+                                _effectiveSessionId ?? widget.sessionId;
+                            if (_looksLikeRealtimeSessionId(quizSessionId))
                               return QuizEditorWidget(
-                                sessionId: widget.sessionId,
+                                key: ValueKey(quizSessionId),
+                                sessionId: quizSessionId,
                               );
                             return const SizedBox.shrink();
                           }

--- a/pentalk_front/lib/screens/session_list_screen.dart
+++ b/pentalk_front/lib/screens/session_list_screen.dart
@@ -145,6 +145,7 @@ class _SessionListScreenState extends State<SessionListScreen> {
                       builder: (context) => SessionDetailScreen(
                         sessionId: session.id,
                         classId: session.classId,
+                        password: session.password,
                       ),
                     ),
                   );

--- a/pentalk_front/lib/screens/teacher_home_screen.dart
+++ b/pentalk_front/lib/screens/teacher_home_screen.dart
@@ -212,6 +212,7 @@ class _TeacherHomeScreenState extends State<TeacherHomeScreen> {
                       builder: (_) => SessionDetailScreen(
                         sessionId: session.id,
                         classId: session.classId,
+                        password: session.password,
                       ),
                     ),
                   );


### PR DESCRIPTION
## 📌 Summary
교사가 퀴즈를 등록한 세션과 학생이 실제로 응시하는 세션의 ID가 서로 달라 "등록된 퀴즈 없음"이 뜨던 문제를 수정했습니다. 또한 세션 자동 생성 시 capacity, password 값이 누락되어 발생하던 SESSION_CAPACITY_INVALID, SESSION_PASSWORD_REQUIRED 에러를 해결했습니다.

## 🔧 변경 사항

QuizEditorWidget이 고정된 widget.sessionId 대신 실시간 활성 세션(_effectiveSessionId)을 참조하도록 수정
SessionDetailScreen에 password 파라미터 추가 — 교사가 지정한 세션 비밀번호가 자동 재생성 세션에도 그대로 유지되도록 수정
material_detail_screen.dart, session_detail_screen.dart의 자동 세션 생성 로직에 capacity(30), password 값 명시적 전달
session_list_screen.dart, teacher_home_screen.dart에서 SessionDetailScreen 진입 시 session.password 전달하도록 수정

## ✅ 테스트
교사가 세션 생성 시 지정한 비밀번호로 학생이 정상 입장되는지 확인
PDF 업로드 후 자동 재생성된 세션에 퀴즈 등록 시, 학생이 동일 세션에서 퀴즈를 정상 조회하는지 확인