### PR TITLE
퀴즈 재응시 카운트(isRetryStart) 연동 및 로드 실패시 에러 화면 추가

### DIFF
--- a/pentalk_front/lib/models/quiz_model.dart
+++ b/pentalk_front/lib/models/quiz_model.dart
@@ -97,6 +97,7 @@ enum QuizStatus {
   failed,            // 미통과 (60% 미만)
   dailyLimitExceeded,// 하루 2회 초과 (429)
   noQuestions,       // 등록된 문항 없음
+  error,             // 로드 실패
 }
 
 /// 하루 2회 초과 예외

--- a/pentalk_front/lib/providers/quiz_provider.dart
+++ b/pentalk_front/lib/providers/quiz_provider.dart
@@ -19,6 +19,9 @@ class QuizProvider extends ChangeNotifier {
   /// questionId → 제출 결과
   final Map<String, QuizSubmitResult> _results = {};
 
+  /// 다음 submitAll()이 재응시 시작인지 여부 (resetForRetry()에서 true로 설정)
+  bool _isRetryAttempt = false;
+
   // ── Getters ───────────────────────────────────────────────
   List<QuizQuestion> get questions =>
       List.unmodifiable(_questions..sort((a, b) => a.order.compareTo(b.order)));
@@ -52,11 +55,14 @@ class QuizProvider extends ChangeNotifier {
 
   // ── 학생: 문항 로드 ──────────────────────────────────────
   Future<void> loadQuestionsForStudent(String sessionId) async {
+    debugPrint('🎯 Quiz load: sessionId=$sessionId');
     _setStatus(QuizStatus.loading);
 
     try {
       final questions =
       await ApiService.getQuizQuestions(sessionId: sessionId);
+
+      debugPrint('✅ Quiz loaded: ${questions.length}문제');
 
       if (questions.isEmpty) {
         _questions = [];
@@ -67,9 +73,9 @@ class QuizProvider extends ChangeNotifier {
       _questions = questions;
       _setStatus(QuizStatus.ready);
     } catch (e) {
-      _errorMessage = '퀴즈를 불러오지 못했습니다';
-      _setStatus(QuizStatus.idle);
-      debugPrint('QuizProvider.loadQuestionsForStudent error: $e');
+      debugPrint('❌ Quiz load error: $e');
+      _errorMessage = '퀴즈를 불러오지 못했습니다\n$e';
+      _setStatus(QuizStatus.error);
     }
   }
 
@@ -86,14 +92,30 @@ class QuizProvider extends ChangeNotifier {
 
     _setStatus(QuizStatus.submitting);
 
+    // 재응시 시작 여부는 이번 제출의 첫 문항에서만 표시하고 즉시 소비한다
+    final isRetryAttempt = _isRetryAttempt;
+    _isRetryAttempt = false;
+
     try {
       // 문항 순서대로 순차 제출
-      for (final question in _questions) {
+      for (int i = 0; i < _questions.length; i++) {
+        final question = _questions[i];
         final answer = _studentAnswers[question.id]!;
+        debugPrint(
+          '📝 Submitting quiz answer: questionId=${question.id}, '
+          'myAnswer=$answer, teacherAnswer(local)=${question.answer}, '
+          'isRetryStart=${i == 0 && isRetryAttempt}',
+        );
         final result = await ApiService.submitQuizAnswer(
           sessionId: sessionId,
           questionId: question.id,
           answer: answer,
+          isRetryStart: i == 0 && isRetryAttempt,
+        );
+        debugPrint(
+          '📩 Quiz submit result: questionId=${result.questionId}, '
+          'isCorrect=${result.isCorrect}, submittedAnswer=${result.submittedAnswer}, '
+          'correctAnswer=${result.correctAnswer}',
         );
         _results[question.id] = result;
       }
@@ -114,6 +136,7 @@ class QuizProvider extends ChangeNotifier {
     _studentAnswers.clear();
     _results.clear();
     _errorMessage = null;
+    _isRetryAttempt = true;
     _setStatus(QuizStatus.ready);
   }
 

--- a/pentalk_front/lib/screens/quiz_screen.dart
+++ b/pentalk_front/lib/screens/quiz_screen.dart
@@ -70,6 +70,11 @@ class _QuizScreenState extends State<QuizScreen> {
             builder: (context, provider, _) {
               return switch (provider.status) {
                 QuizStatus.idle || QuizStatus.loading => const _LoadingView(),
+                QuizStatus.error => _ErrorView(
+                  message: provider.errorMessage ?? '퀴즈를 불러오지 못했습니다',
+                  onRetry: () => provider.loadQuestionsForStudent(widget.sessionId),
+                  onClose: widget.onClose,
+                ),
                 QuizStatus.noQuestions => _NoQuestionsView(onClose: widget.onClose),
                 QuizStatus.ready => _QuizFormView(
                   provider: provider,
@@ -777,6 +782,60 @@ class _AnswerChip extends StatelessWidget {
           fontSize: 12,
           color: color[700],
           fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+// ── 에러 뷰 ─────────────────────────────────────────────────
+class _ErrorView extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+  final VoidCallback onClose;
+
+  const _ErrorView({
+    required this.message,
+    required this.onRetry,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.error_outline, size: 64, color: Colors.red[300]),
+            const SizedBox(height: 20),
+            const Text(
+              '퀴즈를 불러오지 못했습니다',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+            ),
+            const SizedBox(height: 32),
+            ElevatedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('다시 시도'),
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextButton(
+              onPressed: onClose,
+              child: Text('닫기', style: TextStyle(color: Colors.grey[600])),
+            ),
+          ],
         ),
       ),
     );

--- a/pentalk_front/lib/services/api_service.dart
+++ b/pentalk_front/lib/services/api_service.dart
@@ -981,6 +981,7 @@ class ApiService {
     required String sessionId,
     required String questionId,
     required String answer,
+    bool isRetryStart = false,
   }) async {
     final token = await AuthService.getToken();
     final uri = Uri.parse(
@@ -993,7 +994,11 @@ class ApiService {
         'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
-      body: jsonEncode({'questionId': questionId, 'answer': answer}),
+      body: jsonEncode({
+        'questionId': questionId,
+        'answer': answer,
+        'isRetryStart': isRetryStart,
+      }),
     );
 
     if (response.statusCode == 200 || response.statusCode == 201) {


### PR DESCRIPTION
## 📌 Summary
서버의 퀴즈 재응시 일일 횟수 제한 검증을 위한 isRetryStart 필드를 연동하고, 퀴즈 문항 로드 실패 시 무한 로딩 화면에서 멈추던 문제를 에러 화면으로 개선했습니다.

## 🔧 변경 사항

POST /quiz/submit 요청에 isRetryStart 필드 추가 — 재응시(다시 도전) 세트의 첫 번째 문항 제출에만 true를 전송하도록 구현
QuizStatus에 error 상태 추가, 로드 실패 시 재시도 버튼이 있는 _ErrorView 표시하도록 수정
퀴즈 제출/응답 확인을 위한 디버그 로그 추가 (📝 Submitting, 📩 Quiz submit result)

## ✅ 테스트
최초 응시 시 정답 제출 → isCorrect: true 정상 반영 확인
미통과 후 "다시 도전" → 정답 수정 제출 시 재채점되어 통과 처리되는지 확인
재응시 2회 진행 후 3번째 재응시 시작 시 429 QUIZ_DAILY_LIMIT_EXCEEDED 확인
퀴즈 API 실패 시 무한 로딩 대신 에러 화면 + 재시도 버튼 노출 확인