### PR TITLE
feat: UI 전체 리디자인 및 실시간 동기화 버그 수정

### DIFF
--- a/pentalk_front/lib/main.dart
+++ b/pentalk_front/lib/main.dart
@@ -13,6 +13,7 @@ import 'providers/quiz_provider.dart';
 import 'screens/join_session_screen.dart';
 import 'screens/splash_screen.dart';
 import 'services/deep_link_service.dart';
+import 'theme/app_colors.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -45,13 +46,22 @@ class MyApp extends StatelessWidget {
         title: '하이브리드 교실',
         debugShowCheckedModeBanner: false,
         theme: ThemeData(
-          primarySwatch: Colors.blue,
           useMaterial3: true,
           colorScheme: ColorScheme.fromSeed(
-            seedColor: Colors.blue,
+            seedColor: AppColors.primary,
             brightness: Brightness.light,
           ),
-          appBarTheme: const AppBarTheme(centerTitle: false, elevation: 0),
+          scaffoldBackgroundColor: AppColors.background,
+          appBarTheme: const AppBarTheme(
+            centerTitle: false,
+            elevation: 0,
+            backgroundColor: AppColors.surface,
+            foregroundColor: AppColors.textPrimary,
+          ),
+          textTheme: const TextTheme().apply(
+            bodyColor: AppColors.textPrimary,
+            displayColor: AppColors.textPrimary,
+          ),
         ),
 
         onGenerateInitialRoutes: (initialRoute) {

--- a/pentalk_front/lib/providers/student_session_provider.dart
+++ b/pentalk_front/lib/providers/student_session_provider.dart
@@ -53,22 +53,26 @@ class StudentSessionProvider extends ChangeNotifier {
   }
 
   // 내가 참여한 세션 목록 불러오기
+  // 주의: addJoinedSession()으로 이미 기록된 실제 참여 세션은
+  // 여기서 덮어쓰지 않는다 (홈 화면 재진입 시마다 호출되므로).
   Future<void> loadMySessions() async {
     _isLoading = true;
     _errorMessage = null;
     notifyListeners();
 
     try {
-      _sessions = [
-        StudentSessionModel(
-          id: _fallbackClassId,
-          title: 'seed-class-01 테스트 수업',
-          classId: _fallbackClassId,
-          teacherName: 'teacher1',
-          subject: '공유 세션',
-          joinedAt: DateTime.now(),
-        ),
-      ];
+      if (_sessions.isEmpty) {
+        _sessions = [
+          StudentSessionModel(
+            id: _fallbackClassId,
+            title: 'seed-class-01 테스트 수업',
+            classId: _fallbackClassId,
+            teacherName: 'teacher1',
+            subject: '공유 세션',
+            joinedAt: DateTime.now(),
+          ),
+        ];
+      }
 
       _isLoading = false;
       notifyListeners();

--- a/pentalk_front/lib/screens/drawing_screen.dart
+++ b/pentalk_front/lib/screens/drawing_screen.dart
@@ -22,11 +22,13 @@ import '../widgets/poll_overlay.dart';
 import '../widgets/poll_result_sheet.dart';
 import '../widgets/poll_start_dialog.dart';
 import '../widgets/qr_view.dart';
+import '../widgets/quiz_editor_widget.dart';
 import '../services/api_service.dart';
 import '../services/deep_link_service.dart';
 import '../services/pdf_document_service.dart';
 import '../services/pdf_export_service.dart';
 import '../services/pdf_file_service.dart';
+import '../theme/app_colors.dart';
 import 'student_home_screen.dart';
 import 'teacher_home_screen.dart';
 import 'quiz_screen.dart';
@@ -450,6 +452,40 @@ class _DrawingScreenState extends State<DrawingScreen> {
     _drawingProvider.socketService.sendPollEnd(pollState.pollData!.pollId);
   }
 
+  /// ===============================
+  /// 교사: 복습 퀴즈 관리 (모달 바텀시트)
+  /// ===============================
+  void _openQuizEditor() {
+    final sessionId = _shareableSessionId;
+    if (sessionId == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('세션 정보가 없어 퀴즈를 관리할 수 없습니다.')));
+      return;
+    }
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.background,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.85,
+        builder: (context, scrollController) => SingleChildScrollView(
+          controller: scrollController,
+          padding: const EdgeInsets.only(top: 8),
+          child: QuizEditorWidget(
+            key: ValueKey(sessionId),
+            sessionId: sessionId,
+          ),
+        ),
+      ),
+    );
+  }
+
   void _showQrCodeDialog() {
     final sessionId = _shareableSessionId;
     if (sessionId == null) {
@@ -817,6 +853,197 @@ class _DrawingScreenState extends State<DrawingScreen> {
     super.dispose();
   }
 
+  Widget _buildSidebar() {
+    return Container(
+      width: 64,
+      color: AppColors.surface,
+      child: SafeArea(
+        child: Column(
+          children: [
+            const SizedBox(height: 8),
+            if (widget.isTeacher)
+              Consumer<PollProvider>(
+                builder: (context, pollProvider, _) {
+                  final isActive = pollProvider.state.isActive;
+                  return _SidebarNavItem(
+                    icon: isActive ? Icons.poll : Icons.poll_outlined,
+                    label: '이해도체크',
+                    isActive: isActive,
+                    onTap: isActive ? _handleEndPoll : _handleStartPoll,
+                  );
+                },
+              ),
+            if (widget.isTeacher)
+              _SidebarNavItem(
+                icon: Icons.quiz_outlined,
+                label: '복습퀴즈',
+                isActive: false,
+                onTap: _openQuizEditor,
+              ),
+            const SizedBox(height: 4),
+            const ParticipantsButton(),
+            const Spacer(),
+            _SidebarNavItem(
+              icon: Icons.logout,
+              label: '나가기',
+              isActive: false,
+              isDanger: true,
+              onTap: widget.isTeacher
+                  ? _endSession
+                  : () => Navigator.maybePop(context),
+            ),
+            const SizedBox(height: 12),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTopBar() {
+    return Container(
+      height: 44,
+      color: AppColors.surface,
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              _documentSource != null
+                  ? '${widget.materialTitle} (${_documentSource!.currentPage}/${_documentSource!.pageCount})'
+                  : widget.materialTitle,
+              style: const TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 14,
+                color: AppColors.textPrimary,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (widget.isReadOnly)
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 8,
+                vertical: 4,
+              ),
+              decoration: BoxDecoration(
+                color: AppColors.accentLight,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: AppColors.accent, width: 1),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    Icons.visibility,
+                    size: 16,
+                    color: AppColors.accent,
+                  ),
+                  const SizedBox(width: 4),
+                  const Text(
+                    '읽기 전용',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.accent,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          if (_hasPagedDocument) ...[
+            const SizedBox(width: 8),
+            IconButton(
+              icon: const Icon(Icons.chevron_left),
+              onPressed: _isPreparingDocument ? null : _goToPreviousPage,
+              tooltip: '이전 페이지',
+            ),
+            Text(
+              '${_documentSource!.currentPage}/${_documentSource!.pageCount}',
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: AppColors.textPrimary,
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.chevron_right),
+              onPressed: _isPreparingDocument ? null : _goToNextPage,
+              tooltip: '다음 페이지',
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildToolbar() {
+    return Container(
+      color: AppColors.surface,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            if (!_usesNativeTeacherDrawing) ...[
+              const ColorPaletteBar(),
+              const SizedBox(width: 12),
+              const WidthSelectorBar(),
+              const SizedBox(width: 12),
+            ],
+            if (widget.isTeacher) ...[
+              if (_shareableSessionId != null)
+                IconButton(
+                  icon: const Icon(Icons.qr_code_2),
+                  onPressed: _showQrCodeDialog,
+                  tooltip: 'QR 코드 공유',
+                ),
+              IconButton(
+                icon: const Icon(Icons.undo),
+                onPressed: _handleUndo,
+                tooltip: '실행 취소',
+              ),
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                onPressed: _handleClear,
+                tooltip: '전체 지우기',
+              ),
+            ] else ...[
+              IconButton(
+                icon: const Icon(Icons.undo),
+                onPressed: _handleStudentUndo,
+                tooltip: '내 필기 실행 취소',
+              ),
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                onPressed: _handleStudentClear,
+                tooltip: '내 필기 전체 지우기',
+              ),
+              _isExporting
+                  ? const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      child: SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            AppColors.primary,
+                          ),
+                        ),
+                      ),
+                    )
+                  : IconButton(
+                      icon: const Icon(Icons.picture_as_pdf),
+                      onPressed: _handleExportPdf,
+                      tooltip: 'PDF 내보내기',
+                    ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     // export 중 뒤로가기 차단
@@ -833,231 +1060,98 @@ class _DrawingScreenState extends State<DrawingScreen> {
         }
       },
       child: Scaffold(
-        appBar: AppBar(
-          title: Row(
-            children: [
-              Expanded(
-                child: Text(
-                  _documentSource != null
-                      ? '${widget.materialTitle} (${_documentSource!.currentPage}/${_documentSource!.pageCount})'
-                      : widget.materialTitle,
-                ),
-              ),
-              if (widget.isReadOnly)
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 4,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Colors.orange[100],
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(color: Colors.orange, width: 1),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        Icons.visibility,
-                        size: 16,
-                        color: Colors.orange[800],
-                      ),
-                      const SizedBox(width: 4),
-                      Text(
-                        '읽기 전용',
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.orange[800],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-            ],
-          ),
-          actions: [
-            if (!widget.isReadOnly) ...[
-              // 교사 전용: 세션 종료 (맨 앞에 배치)
-              if (widget.isTeacher)
-                IconButton(
-                  icon: const Icon(Icons.logout),
-                  onPressed: _endSession,
-                  tooltip: '세션 종료',
-                  color: Colors.red,
-                ),
-
-              if (_hasPagedDocument) ...[
-                IconButton(
-                  icon: const Icon(Icons.chevron_left),
-                  onPressed: _isPreparingDocument ? null : _goToPreviousPage,
-                  tooltip: '이전 페이지',
-                ),
-                Center(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4),
-                    child: Text(
-                      '${_documentSource!.currentPage}/${_documentSource!.pageCount}',
-                      style: const TextStyle(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.chevron_right),
-                  onPressed: _isPreparingDocument ? null : _goToNextPage,
-                  tooltip: '다음 페이지',
-                ),
-              ],
-
-              if (!_usesNativeTeacherDrawing) ...[
-                const ColorPaletteBar(),
-                const SizedBox(width: 8),
-                const WidthSelectorBar(),
-                const SizedBox(width: 8),
-              ],
-
-              // 교사용 컨트롤
-              if (widget.isTeacher) ...[
-                if (_shareableSessionId != null)
-                  IconButton(
-                    icon: const Icon(Icons.qr_code_2),
-                    onPressed: _showQrCodeDialog,
-                    tooltip: 'QR 코드 공유',
-                  ),
-                IconButton(
-                  icon: const Icon(Icons.undo),
-                  onPressed: _handleUndo,
-                  tooltip: '실행 취소',
-                ),
-                IconButton(
-                  icon: const Icon(Icons.delete_outline),
-                  onPressed: _handleClear,
-                  tooltip: '전체 지우기',
-                ),
-                Consumer<PollProvider>(
-                  builder: (context, pollProvider, _) {
-                    final isActive = pollProvider.state.isActive;
-                    return IconButton(
-                      icon: Icon(
-                        isActive ? Icons.poll : Icons.poll_outlined,
-                        color: isActive ? Colors.amber : Colors.black87,
-                      ),
-                      onPressed: isActive ? _handleEndPoll : _handleStartPoll,
-                      tooltip: isActive ? '이해도 체크 종료' : '이해도 체크 시작',
-                    );
-                  },
-                ),
-              ],
-
-              if (!widget.isTeacher) ...[
-                IconButton(
-                  icon: const Icon(Icons.undo),
-                  onPressed: _handleStudentUndo,
-                  tooltip: '내 필기 실행 취소',
-                ),
-                IconButton(
-                  icon: const Icon(Icons.delete_outline),
-                  onPressed: _handleStudentClear,
-                  tooltip: '내 필기 전체 지우기',
-                ),
-              ],
-
-              const ParticipantsButton(),
-
-              // 학생 전용: PDF 내보내기 버튼
-              if (!widget.isTeacher)
-                _isExporting
-                    ? const Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 16),
-                        child: SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            valueColor: AlwaysStoppedAnimation<Color>(
-                              Colors.white,
-                            ),
-                          ),
-                        ),
-                      )
-                    : IconButton(
-                        icon: const Icon(Icons.picture_as_pdf),
-                        onPressed: _handleExportPdf,
-                        tooltip: 'PDF 내보내기',
-                      ),
-
-            ],
-          ],
-        ),
+        backgroundColor: AppColors.background,
         body: (_isConnecting || _isPreparingDocument)
             ? const Center(
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    CircularProgressIndicator(),
+                    CircularProgressIndicator(color: AppColors.primary),
                     SizedBox(height: 16),
                     Text('문서 및 실시간 연결 준비 중...'),
                   ],
                 ),
               )
-            : Stack(
+            : Row(
                 children: [
-                  DrawingCanvasWidget(
-                    isTeacher: widget.isTeacher,
-                    enableTouchInput: true, // 👈 추가 (터치 입력 켜기)
-                    showMyStrokes: true, // 👈 추가 (내 필기 보이기)
-                  ),
+                  if (!widget.isReadOnly) _buildSidebar(),
+                  Expanded(
+                    child: Column(
+                      children: [
+                        _buildTopBar(),
+                        if (!widget.isReadOnly) _buildToolbar(),
+                        Expanded(
+                          child: Stack(
+                            children: [
+                              DrawingCanvasWidget(
+                                isTeacher: widget.isTeacher,
+                                enableTouchInput: true, // 👈 추가 (터치 입력 켜기)
+                                showMyStrokes: true, // 👈 추가 (내 필기 보이기)
+                              ),
 
-                  if (_hasPagedDocument)
-                    Positioned(
-                      bottom: 14,
-                      left: 0,
-                      right: 0,
-                      child: Center(
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 14,
-                            vertical: 8,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Colors.black.withOpacity(0.72),
-                            borderRadius: BorderRadius.circular(18),
-                          ),
-                          child: Text(
-                            '${_documentSource!.currentPage} / ${_documentSource!.pageCount}',
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                            ),
+                              if (_hasPagedDocument)
+                                Positioned(
+                                  bottom: 14,
+                                  left: 0,
+                                  right: 0,
+                                  child: Center(
+                                    child: Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 14,
+                                        vertical: 8,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: Colors.black.withOpacity(0.72),
+                                        borderRadius: BorderRadius.circular(
+                                          18,
+                                        ),
+                                      ),
+                                      child: Text(
+                                        '${_documentSource!.currentPage} / ${_documentSource!.pageCount}',
+                                        style: const TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 12,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+
+                              // 학생: 이해도 체크 팝업 (캔버스 중앙)
+                              if (!widget.isTeacher)
+                                Positioned.fill(
+                                  child: Consumer<PollProvider>(
+                                    builder: (context, pollProvider, _) {
+                                      final state = pollProvider.state;
+                                      if ((!state.isActive &&
+                                              !state.isAnswered) ||
+                                          _pollOverlayDismissed) {
+                                        return const SizedBox.shrink();
+                                      }
+                                      return PollOverlay(
+                                        pollState: state,
+                                        remainingSeconds:
+                                            pollProvider.remainingSeconds,
+                                        onAnswer: _handlePollAnswer,
+                                        onDismiss: state.isAnswered
+                                            ? () => setState(
+                                                () => _pollOverlayDismissed =
+                                                    true,
+                                              )
+                                            : null,
+                                      );
+                                    },
+                                  ),
+                                ),
+                            ],
                           ),
                         ),
-                      ),
+                      ],
                     ),
+                  ),
 
-                  // 학생: 이해도 체크 오버레이
-                  if (!widget.isTeacher)
-                    Consumer<PollProvider>(
-                      builder: (context, pollProvider, _) {
-                        final state = pollProvider.state;
-                        if ((!state.isActive && !state.isAnswered) || _pollOverlayDismissed) {
-                          return const SizedBox.shrink();
-                        }
-                        return PollOverlay(
-                          pollState: state,
-                          remainingSeconds: pollProvider.remainingSeconds,
-                          onAnswer: _handlePollAnswer,
-                          onDismiss: state.isAnswered
-                              ? () => setState(() => _pollOverlayDismissed = true)
-                              : null,
-                        );
-                      },
-                    ),
-
-                  // 교사: 실시간 집계 결과 표시
+                  // 교사: 실시간 집계 결과 좌측 고정 패널
                   if (widget.isTeacher)
                     Consumer<PollProvider>(
                       builder: (context, pollProvider, _) {
@@ -1065,10 +1159,13 @@ class _DrawingScreenState extends State<DrawingScreen> {
                         if (!state.isActive && !state.isEnded) {
                           return const SizedBox.shrink();
                         }
-                        return PollResultSheet(
-                          pollState: state,
-                          remainingSeconds: pollProvider.remainingSeconds,
-                          onClose: () => pollProvider.reset(),
+                        return SizedBox(
+                          width: 170,
+                          child: PollResultSheet(
+                            pollState: state,
+                            remainingSeconds: pollProvider.remainingSeconds,
+                            onClose: () => pollProvider.reset(),
+                          ),
                         );
                       },
                     ),
@@ -1089,7 +1186,7 @@ class _DrawingScreenState extends State<DrawingScreen> {
                           provider.setDrawingMode(!provider.isDrawingMode);
                         },
                         backgroundColor: provider.isDrawingMode
-                            ? Colors.blue
+                            ? AppColors.primary
                             : Colors.grey,
                         tooltip: provider.isDrawingMode
                             ? '이동 모드로 전환'
@@ -1106,7 +1203,7 @@ class _DrawingScreenState extends State<DrawingScreen> {
                         ),
                         decoration: BoxDecoration(
                           color: provider.isDrawingMode
-                              ? Colors.blue.withOpacity(0.9)
+                              ? AppColors.primary.withOpacity(0.9)
                               : Colors.grey.withOpacity(0.9),
                           borderRadius: BorderRadius.circular(20),
                         ),
@@ -1155,7 +1252,7 @@ class _DrawingScreenState extends State<DrawingScreen> {
                           );
                         },
                         backgroundColor: drawingProvider.isDrawingMode
-                            ? Colors.blue
+                            ? AppColors.primary
                             : Colors.grey,
                         tooltip: drawingProvider.isDrawingMode
                             ? '이동 모드로 전환'
@@ -1174,7 +1271,7 @@ class _DrawingScreenState extends State<DrawingScreen> {
                         ),
                         decoration: BoxDecoration(
                           color: drawingProvider.isDrawingMode
-                              ? Colors.blue.withOpacity(0.9)
+                              ? AppColors.primary.withOpacity(0.9)
                               : Colors.grey.withOpacity(0.9),
                           borderRadius: BorderRadius.circular(20),
                         ),
@@ -1280,5 +1377,64 @@ class _DrawingScreenState extends State<DrawingScreen> {
 
     if (confirmed != true) return;
     await context.read<PersonalDrawingProvider>().clearCurrentPage();
+  }
+}
+
+/// ===============================
+/// 판서 화면 좌측 사이드바 내비게이션 아이템
+/// ===============================
+class _SidebarNavItem extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool isActive;
+  final bool isDanger;
+  final VoidCallback onTap;
+
+  const _SidebarNavItem({
+    required this.icon,
+    required this.label,
+    required this.isActive,
+    required this.onTap,
+    this.isDanger = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isDanger
+        ? AppColors.danger
+        : isActive
+        ? AppColors.primary
+        : AppColors.textSecondary;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                color: isActive ? AppColors.primaryLight : Colors.transparent,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(icon, size: 18, color: color),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              label,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 9,
+                fontWeight: isActive ? FontWeight.bold : FontWeight.normal,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/pentalk_front/lib/screens/material_detail_screen.dart
+++ b/pentalk_front/lib/screens/material_detail_screen.dart
@@ -13,6 +13,7 @@ import '../services/deep_link_service.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
 import '../services/pdf_file_service.dart';
+import '../theme/app_colors.dart';
 import 'package:intl/intl.dart';
 import 'drawing_screen.dart';
 
@@ -24,6 +25,10 @@ class MaterialDetailScreen extends StatefulWidget {
   final String? joinUrl;
   final bool isTeacher;
   final String? classId;
+
+  /// 복습 퀴즈 통과 여부 (null이면 퀴즈와 무관한 일반 자료 열람)
+  /// true: 통과 · 필기 가능 배지 / false: 미통과 · 읽기 전용 배지 + 잠금
+  final bool? quizPassed;
 
   static const String _demoClassId = String.fromEnvironment(
     'PENTALK_DEMO_CLASS_ID',
@@ -56,6 +61,7 @@ class MaterialDetailScreen extends StatefulWidget {
     this.joinUrl,
     this.isTeacher = false,
     this.classId,
+    this.quizPassed,
   }) : super(key: key);
 
   @override
@@ -96,17 +102,19 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
   Color _getMaterialIconColor() {
     switch (widget.material.type) {
       case FileMaterialType.pdf:
-        return Colors.red;
+        return AppColors.danger;
       case FileMaterialType.image:
-        return Colors.blue;
+        return AppColors.primary;
       case FileMaterialType.video:
         return Colors.purple;
       case FileMaterialType.document:
-        return Colors.green;
+        return AppColors.success;
       case FileMaterialType.other:
-        return Colors.grey;
+        return AppColors.textSecondary;
     }
   }
+
+  bool get _isLocked => widget.quizPassed == false;
 
   String _formatDate(DateTime date) {
     return DateFormat('yyyy년 MM월 dd일 HH:mm').format(date);
@@ -144,7 +152,7 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('다운로드 실패: $e'), backgroundColor: Colors.red),
+        SnackBar(content: Text('다운로드 실패: $e'), backgroundColor: AppColors.danger),
       );
     } finally {
       if (mounted) {
@@ -392,6 +400,7 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.background,
       appBar: AppBar(
         title: const Text('자료 상세'),
         actions: [
@@ -408,11 +417,14 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                 child: SizedBox(
                   width: 20,
                   height: 20,
-                  child: CircularProgressIndicator(strokeWidth: 2),
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: AppColors.primary,
+                  ),
                 ),
               ),
             )
-          else
+          else if (!_isLocked)
             IconButton(
               icon: const Icon(Icons.download),
               onPressed: _handleDownload,
@@ -424,11 +436,54 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            if (widget.quizPassed != null)
+              Container(
+                width: double.infinity,
+                color: widget.quizPassed!
+                    ? const Color(0xFFE7F5EA)
+                    : AppColors.border,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 10,
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      widget.quizPassed! ? Icons.check_circle : Icons.lock_outline,
+                      size: 16,
+                      color: widget.quizPassed!
+                          ? AppColors.success
+                          : AppColors.textSecondary,
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      widget.quizPassed! ? '통과 · 필기 가능' : '미통과 · 읽기 전용',
+                      style: TextStyle(
+                        fontSize: 12.5,
+                        fontWeight: FontWeight.bold,
+                        color: widget.quizPassed!
+                            ? AppColors.success
+                            : AppColors.textSecondary,
+                      ),
+                    ),
+                    if (_isLocked) ...[
+                      const Spacer(),
+                      const Text(
+                        '복습 퀴즈를 통과하면 다시 필기할 수 있어요',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: AppColors.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
             Container(
               width: double.infinity,
               padding: const EdgeInsets.all(32),
               decoration: BoxDecoration(
-                color: _getMaterialIconColor().withOpacity(0.1),
+                color: _getMaterialIconColor().withOpacity(0.08),
               ),
               child: Column(
                 children: [
@@ -436,11 +491,11 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                     width: 120,
                     height: 120,
                     decoration: BoxDecoration(
-                      color: Colors.white,
+                      color: AppColors.surface,
                       borderRadius: BorderRadius.circular(20),
                       boxShadow: [
                         BoxShadow(
-                          color: Colors.black.withOpacity(0.1),
+                          color: Colors.black.withOpacity(0.08),
                           blurRadius: 10,
                           offset: const Offset(0, 4),
                         ),
@@ -449,7 +504,9 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                     child: Icon(
                       _getMaterialIcon(),
                       size: 64,
-                      color: _getMaterialIconColor(),
+                      color: _isLocked
+                          ? AppColors.textSecondary
+                          : _getMaterialIconColor(),
                     ),
                   ),
                   const SizedBox(height: 16),
@@ -457,7 +514,9 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                     widget.material.type.name.toUpperCase(),
                     style: TextStyle(
                       fontSize: 14,
-                      color: _getMaterialIconColor(),
+                      color: _isLocked
+                          ? AppColors.textSecondary
+                          : _getMaterialIconColor(),
                       fontWeight: FontWeight.bold,
                       letterSpacing: 1.2,
                     ),
@@ -474,7 +533,7 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                     '제목',
                     style: TextStyle(
                       fontSize: 14,
-                      color: Colors.grey,
+                      color: AppColors.textSecondary,
                       fontWeight: FontWeight.w500,
                     ),
                   ),
@@ -484,12 +543,17 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                     style: const TextStyle(
                       fontSize: 24,
                       fontWeight: FontWeight.bold,
+                      color: AppColors.textPrimary,
                     ),
                   ),
                   const SizedBox(height: 24),
                   Card(
                     elevation: 0,
-                    color: Colors.grey[100],
+                    color: AppColors.surface,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      side: const BorderSide(color: AppColors.border),
+                    ),
                     child: Padding(
                       padding: const EdgeInsets.all(16),
                       child: Column(
@@ -528,7 +592,7 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                       '설명',
                       style: TextStyle(
                         fontSize: 14,
-                        color: Colors.grey,
+                        color: AppColors.textSecondary,
                         fontWeight: FontWeight.w500,
                       ),
                     ),
@@ -537,12 +601,17 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                       width: double.infinity,
                       padding: const EdgeInsets.all(16),
                       decoration: BoxDecoration(
-                        color: Colors.grey[100],
+                        color: AppColors.surface,
                         borderRadius: BorderRadius.circular(12),
+                        border: Border.all(color: AppColors.border),
                       ),
                       child: Text(
                         widget.material.description!,
-                        style: const TextStyle(fontSize: 15, height: 1.5),
+                        style: const TextStyle(
+                          fontSize: 15,
+                          height: 1.5,
+                          color: AppColors.textPrimary,
+                        ),
                       ),
                     ),
                     const SizedBox(height: 24),
@@ -552,10 +621,14 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                       SizedBox(
                         width: double.infinity,
                         child: ElevatedButton.icon(
-                          onPressed: () => _handleStartDrawing(context),
+                          onPressed: _isLocked
+                              ? null
+                              : () => _handleStartDrawing(context),
                           icon: const Icon(Icons.edit),
                           label: Text(widget.isTeacher ? '판서 시작' : '내 필기 시작'),
                           style: ElevatedButton.styleFrom(
+                            backgroundColor: AppColors.primary,
+                            foregroundColor: Colors.white,
                             padding: const EdgeInsets.symmetric(vertical: 16),
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(12),
@@ -572,6 +645,8 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                               icon: const Icon(Icons.visibility_outlined),
                               label: const Text('미리보기'),
                               style: OutlinedButton.styleFrom(
+                                foregroundColor: AppColors.primary,
+                                side: const BorderSide(color: AppColors.primary),
                                 padding: const EdgeInsets.symmetric(
                                   vertical: 16,
                                 ),
@@ -584,7 +659,7 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                           const SizedBox(width: 12),
                           Expanded(
                             child: ElevatedButton.icon(
-                              onPressed: _isDownloading
+                              onPressed: _isLocked || _isDownloading
                                   ? null
                                   : _handleDownload,
                               icon: _isDownloading
@@ -602,6 +677,8 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                                   : const Icon(Icons.download),
                               label: Text(_isDownloading ? '저장 중...' : '다운로드'),
                               style: ElevatedButton.styleFrom(
+                                backgroundColor: AppColors.primary,
+                                foregroundColor: Colors.white,
                                 padding: const EdgeInsets.symmetric(
                                   vertical: 16,
                                 ),
@@ -627,7 +704,7 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
   Widget _buildInfoRow(IconData icon, String label, String value) {
     return Row(
       children: [
-        Icon(icon, size: 20, color: Colors.grey[600]),
+        Icon(icon, size: 20, color: AppColors.textSecondary),
         const SizedBox(width: 12),
         Expanded(
           child: Column(
@@ -635,7 +712,10 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
             children: [
               Text(
                 label,
-                style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: AppColors.textSecondary,
+                ),
               ),
               const SizedBox(height: 4),
               Text(
@@ -643,6 +723,7 @@ class _MaterialDetailScreenState extends State<MaterialDetailScreen> {
                 style: const TextStyle(
                   fontSize: 14,
                   fontWeight: FontWeight.w500,
+                  color: AppColors.textPrimary,
                 ),
               ),
             ],

--- a/pentalk_front/lib/screens/material_library_screen.dart
+++ b/pentalk_front/lib/screens/material_library_screen.dart
@@ -1,0 +1,345 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../models/student_session_model.dart';
+import '../providers/session_provider.dart';
+import '../providers/student_session_provider.dart';
+import '../services/api_service.dart';
+import '../theme/app_colors.dart';
+import 'material_detail_screen.dart';
+
+/// ===============================
+/// 자료 보관함
+/// 내가 속한 모든 클래스의 자료를 모아서 보여줌
+/// ===============================
+class MaterialLibraryScreen extends StatefulWidget {
+  final bool isTeacher;
+
+  const MaterialLibraryScreen({Key? key, required this.isTeacher})
+    : super(key: key);
+
+  @override
+  State<MaterialLibraryScreen> createState() => _MaterialLibraryScreenState();
+}
+
+class _MaterialLibraryScreenState extends State<MaterialLibraryScreen> {
+  bool _isLoading = true;
+  String? _errorMessage;
+  List<MaterialUploadResponse> _materials = [];
+  String _query = '';
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadMaterials());
+  }
+
+  Future<void> _loadMaterials() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final classIds = widget.isTeacher
+          ? context
+                .read<SessionProvider>()
+                .sessions
+                .map((s) => s.classId)
+                .whereType<String>()
+                .toSet()
+          : context
+                .read<StudentSessionProvider>()
+                .sessions
+                .map((s) => s.classId)
+                .whereType<String>()
+                .toSet();
+
+      debugPrint(
+        '📚 Material library: role=${widget.isTeacher ? "teacher" : "student"}, '
+        'classIds=$classIds',
+      );
+      if (!widget.isTeacher) {
+        final rawSessions = context.read<StudentSessionProvider>().sessions;
+        debugPrint(
+          '📚 StudentSessionProvider.sessions: '
+          '${rawSessions.map((s) => "(id=${s.id}, classId=${s.classId})").toList()}',
+        );
+      }
+
+      final collected = <MaterialUploadResponse>[];
+      for (final classId in classIds) {
+        try {
+          final items = await ApiService.getMaterials(classId: classId);
+          collected.addAll(items);
+        } catch (e) {
+          debugPrint('⚠️ 자료 조회 실패 (classId=$classId): $e');
+        }
+      }
+
+      collected.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+
+      if (!mounted) return;
+      setState(() {
+        _materials = collected;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _errorMessage = '자료를 불러오지 못했습니다';
+        _isLoading = false;
+      });
+    }
+  }
+
+  List<MaterialUploadResponse> get _filtered {
+    if (_query.trim().isEmpty) return _materials;
+    final q = _query.trim().toLowerCase();
+    return _materials.where((m) => m.name.toLowerCase().contains(q)).toList();
+  }
+
+  void _openMaterial(MaterialUploadResponse item) {
+    final material = MaterialModel(
+      id: item.id,
+      title: item.name,
+      fileName: item.name,
+      url: item.url,
+      sizeInBytes: 0,
+      uploadedAt: DateTime.tryParse(item.createdAt) ?? DateTime.now(),
+      type: FileMaterialType.fromString(item.type),
+    );
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => MaterialDetailScreen(
+          material: material,
+          sessionTitle: item.name,
+          teacherName: '',
+          classId: item.classId,
+          isTeacher: widget.isTeacher,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: Row(
+          children: [
+            Container(
+              width: 30,
+              height: 30,
+              decoration: BoxDecoration(
+                color: AppColors.primaryLight,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Icon(
+                Icons.folder_outlined,
+                color: AppColors.primary,
+                size: 16,
+              ),
+            ),
+            const SizedBox(width: 8),
+            const Text(
+              '자료 보관함',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+          ],
+        ),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+            child: Container(
+              decoration: BoxDecoration(
+                color: AppColors.surface,
+                border: Border.all(color: AppColors.border),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: TextField(
+                onChanged: (v) => setState(() => _query = v),
+                decoration: const InputDecoration(
+                  hintText: '자료 검색',
+                  hintStyle: TextStyle(color: AppColors.textSecondary),
+                  prefixIcon: Icon(
+                    Icons.search,
+                    color: AppColors.textSecondary,
+                  ),
+                  border: InputBorder.none,
+                  contentPadding: EdgeInsets.symmetric(vertical: 12),
+                ),
+              ),
+            ),
+          ),
+          Expanded(child: _buildBody()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppColors.primary),
+      );
+    }
+
+    if (_errorMessage != null) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              size: 56,
+              color: AppColors.textSecondary,
+            ),
+            const SizedBox(height: 12),
+            Text(_errorMessage!),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _loadMaterials,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primary,
+              ),
+              child: const Text('다시 시도'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final items = _filtered;
+    if (items.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(
+              Icons.folder_open,
+              size: 64,
+              color: AppColors.textSecondary,
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              '보관된 자료가 없습니다',
+              style: TextStyle(color: AppColors.textSecondary),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      itemCount: items.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 10),
+      itemBuilder: (context, index) => _MaterialRow(
+        item: items[index],
+        onTap: () => _openMaterial(items[index]),
+      ),
+    );
+  }
+}
+
+class _MaterialRow extends StatelessWidget {
+  final MaterialUploadResponse item;
+  final VoidCallback onTap;
+
+  const _MaterialRow({required this.item, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final createdAt = DateTime.tryParse(item.createdAt);
+    final dateLabel = createdAt != null
+        ? DateFormat('yyyy.MM.dd').format(createdAt)
+        : '';
+
+    return Material(
+      color: AppColors.surface,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          decoration: BoxDecoration(
+            border: Border.all(color: AppColors.border),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 34,
+                height: 38,
+                decoration: BoxDecoration(
+                  gradient: const LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [Color(0xFFF87171), Color(0xFFEF4444)],
+                  ),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                alignment: Alignment.center,
+                child: const Text(
+                  'PDF',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w900,
+                    fontSize: 9.5,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      item.name,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                        color: AppColors.textPrimary,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      dateLabel,
+                      style: const TextStyle(
+                        fontSize: 11.5,
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                width: 30,
+                height: 30,
+                decoration: const BoxDecoration(
+                  color: AppColors.primary,
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.download,
+                  color: Colors.white,
+                  size: 16,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pentalk_front/lib/screens/quiz_screen.dart
+++ b/pentalk_front/lib/screens/quiz_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/quiz_model.dart';
 import '../providers/quiz_provider.dart';
+import '../theme/app_colors.dart';
 
 /// ===============================
 /// 학생용 복습 퀴즈 화면
@@ -64,7 +65,7 @@ class _QuizScreenState extends State<QuizScreen> {
     return PopScope(
       canPop: false, // 뒤로가기 비활성화 (퀴즈 중간 이탈 방지)
       child: Scaffold(
-        backgroundColor: const Color(0xFFF5F7FA),
+        backgroundColor: AppColors.background,
         body: SafeArea(
           child: Consumer<QuizProvider>(
             builder: (context, provider, _) {
@@ -132,9 +133,12 @@ class _LoadingView extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const CircularProgressIndicator(),
+          const CircularProgressIndicator(color: AppColors.primary),
           const SizedBox(height: 20),
-          Text(message, style: const TextStyle(fontSize: 16, color: Colors.grey)),
+          Text(
+            message,
+            style: const TextStyle(fontSize: 16, color: AppColors.textSecondary),
+          ),
         ],
       ),
     );
@@ -155,21 +159,26 @@ class _NoQuestionsView extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.quiz_outlined, size: 72, color: Colors.grey[400]),
+            const Icon(
+              Icons.quiz_outlined,
+              size: 72,
+              color: AppColors.textSecondary,
+            ),
             const SizedBox(height: 20),
-            Text(
+            const Text(
               '등록된 퀴즈가 없습니다',
-              style: TextStyle(fontSize: 20, color: Colors.grey[600]),
+              style: TextStyle(fontSize: 20, color: AppColors.textPrimary),
             ),
             const SizedBox(height: 8),
-            Text(
+            const Text(
               '교사가 퀴즈를 등록하지 않았습니다.\nPDF를 바로 다운로드할 수 있습니다.',
               textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 14, color: Colors.grey[500]),
+              style: TextStyle(fontSize: 14, color: AppColors.textSecondary),
             ),
             const SizedBox(height: 32),
             ElevatedButton(
               onPressed: onClose,
+              style: ElevatedButton.styleFrom(backgroundColor: AppColors.primary),
               child: const Text('닫기'),
             ),
           ],
@@ -179,61 +188,68 @@ class _NoQuestionsView extends StatelessWidget {
   }
 }
 
-// ── 퀴즈 폼 뷰 ───────────────────────────────────────────────
-class _QuizFormView extends StatelessWidget {
+// ── 퀴즈 폼 뷰 (한 문제씩 진행) ─────────────────────────────
+class _QuizFormView extends StatefulWidget {
   final QuizProvider provider;
   final VoidCallback onSubmit;
 
   const _QuizFormView({required this.provider, required this.onSubmit});
 
   @override
+  State<_QuizFormView> createState() => _QuizFormViewState();
+}
+
+class _QuizFormViewState extends State<_QuizFormView> {
+  int _currentIndex = 0;
+
+  @override
   Widget build(BuildContext context) {
-    final questions = provider.questions;
+    final questions = widget.provider.questions;
+    final currentQuestion = questions[_currentIndex];
+    final isLast = _currentIndex == questions.length - 1;
+    final hasAnswer =
+        widget.provider.studentAnswers.containsKey(currentQuestion.id);
 
     return Column(
       children: [
-        // 헤더
-        _QuizHeader(totalCount: questions.length),
-
-        // 문항 목록
+        _QuizProgressHeader(
+          current: _currentIndex + 1,
+          total: questions.length,
+        ),
         Expanded(
-          child: SingleChildScrollView(
+          child: Padding(
             padding: const EdgeInsets.all(20),
-            child: Column(
-              children: [
-                for (int i = 0; i < questions.length; i++) ...[
-                  _QuestionCard(
-                    index: i,
-                    question: questions[i],
-                    selectedAnswer: provider.studentAnswers[questions[i].id],
-                    onAnswerSelected: (answer) =>
-                        provider.setAnswer(questions[i].id, answer),
-                  ),
-                  if (i < questions.length - 1) const SizedBox(height: 16),
-                ],
-                const SizedBox(height: 24),
-              ],
+            child: _QuestionCard(
+              index: _currentIndex,
+              question: currentQuestion,
+              selectedAnswer: widget.provider.studentAnswers[currentQuestion.id],
+              onAnswerSelected: (answer) =>
+                  widget.provider.setAnswer(currentQuestion.id, answer),
             ),
           ),
         ),
-
-        // 제출 버튼
-        _SubmitBar(
-          answeredCount: provider.studentAnswers.length,
-          totalCount: questions.length,
-          canSubmit: provider.allAnswered,
-          onSubmit: onSubmit,
+        _NavBar(
+          canProceed: hasAnswer,
+          isLast: isLast,
+          onNext: () {
+            if (isLast) {
+              widget.onSubmit();
+            } else {
+              setState(() => _currentIndex++);
+            }
+          },
         ),
       ],
     );
   }
 }
 
-// ── 퀴즈 헤더 ────────────────────────────────────────────────
-class _QuizHeader extends StatelessWidget {
-  final int totalCount;
+// ── 퀴즈 진행바 헤더 ──────────────────────────────────────────
+class _QuizProgressHeader extends StatelessWidget {
+  final int current;
+  final int total;
 
-  const _QuizHeader({required this.totalCount});
+  const _QuizProgressHeader({required this.current, required this.total});
 
   @override
   Widget build(BuildContext context) {
@@ -241,10 +257,10 @@ class _QuizHeader extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 16),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: AppColors.surface,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.06),
+            color: Colors.black.withOpacity(0.05),
             blurRadius: 8,
             offset: const Offset(0, 2),
           ),
@@ -254,34 +270,36 @@ class _QuizHeader extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Container(
-                padding:
-                const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                decoration: BoxDecoration(
-                  color: Colors.blue[50],
-                  borderRadius: BorderRadius.circular(20),
+              const Text(
+                '복습 퀴즈',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.textPrimary,
                 ),
-                child: Text(
-                  '복습 퀴즈',
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.blue[700],
-                  ),
+              ),
+              Text(
+                '$current / $total 문항',
+                style: const TextStyle(
+                  fontSize: 12.5,
+                  color: AppColors.textSecondary,
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 8),
-          const Text(
-            'PDF를 받으려면 퀴즈를 통과하세요',
-            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            '$totalCount문제 중 ${(totalCount * 0.6).ceil()}문제 이상 맞히면 통과!',
-            style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+          const SizedBox(height: 10),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: current / total,
+              minHeight: 6,
+              backgroundColor: AppColors.border,
+              valueColor: const AlwaysStoppedAnimation<Color>(
+                AppColors.primary,
+              ),
+            ),
           ),
         ],
       ),
@@ -306,12 +324,14 @@ class _QuestionCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
+      width: double.infinity,
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: AppColors.surface,
         borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.06),
+            color: Colors.black.withOpacity(0.05),
             blurRadius: 10,
             offset: const Offset(0, 2),
           ),
@@ -329,8 +349,8 @@ class _QuestionCard extends StatelessWidget {
                 Container(
                   width: 28,
                   height: 28,
-                  decoration: BoxDecoration(
-                    color: Colors.blue[600],
+                  decoration: const BoxDecoration(
+                    color: AppColors.primary,
                     shape: BoxShape.circle,
                   ),
                   child: Center(
@@ -352,6 +372,7 @@ class _QuestionCard extends StatelessWidget {
                       fontSize: 16,
                       fontWeight: FontWeight.w500,
                       height: 1.5,
+                      color: AppColors.textPrimary,
                     ),
                   ),
                 ),
@@ -366,7 +387,7 @@ class _QuestionCard extends StatelessWidget {
                   child: _OxButton(
                     label: 'O',
                     isSelected: selectedAnswer == 'O',
-                    color: Colors.green,
+                    color: AppColors.success,
                     onTap: () => onAnswerSelected('O'),
                   ),
                 ),
@@ -375,7 +396,7 @@ class _QuestionCard extends StatelessWidget {
                   child: _OxButton(
                     label: 'X',
                     isSelected: selectedAnswer == 'X',
-                    color: Colors.red,
+                    color: AppColors.danger,
                     onTap: () => onAnswerSelected('X'),
                   ),
                 ),
@@ -408,10 +429,10 @@ class _OxButton extends StatelessWidget {
       duration: const Duration(milliseconds: 180),
       height: 56,
       decoration: BoxDecoration(
-        color: isSelected ? color.withOpacity(0.12) : Colors.grey[50],
+        color: isSelected ? color.withOpacity(0.12) : AppColors.background,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: isSelected ? color : Colors.grey[300]!,
+          color: isSelected ? color : AppColors.border,
           width: isSelected ? 2.5 : 1,
         ),
       ),
@@ -433,18 +454,16 @@ class _OxButton extends StatelessWidget {
   }
 }
 
-// ── 제출 바 ──────────────────────────────────────────────────
-class _SubmitBar extends StatelessWidget {
-  final int answeredCount;
-  final int totalCount;
-  final bool canSubmit;
-  final VoidCallback onSubmit;
+// ── 하단 네비게이션 바 (다음 문항 / 제출하기) ──────────────
+class _NavBar extends StatelessWidget {
+  final bool canProceed;
+  final bool isLast;
+  final VoidCallback onNext;
 
-  const _SubmitBar({
-    required this.answeredCount,
-    required this.totalCount,
-    required this.canSubmit,
-    required this.onSubmit,
+  const _NavBar({
+    required this.canProceed,
+    required this.isLast,
+    required this.onNext,
   });
 
   @override
@@ -452,10 +471,10 @@ class _SubmitBar extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: AppColors.surface,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.06),
+            color: Colors.black.withOpacity(0.05),
             blurRadius: 8,
             offset: const Offset(0, -2),
           ),
@@ -466,28 +485,28 @@ class _SubmitBar extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            if (!canSubmit)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 8),
+            if (!canProceed)
+              const Padding(
+                padding: EdgeInsets.only(bottom: 8),
                 child: Text(
-                  '$answeredCount / $totalCount 문제 답변 완료',
+                  '답을 선택해주세요',
                   textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 13, color: Colors.grey[500]),
+                  style: TextStyle(fontSize: 13, color: AppColors.textSecondary),
                 ),
               ),
             ElevatedButton(
-              onPressed: canSubmit ? onSubmit : null,
+              onPressed: canProceed ? onNext : null,
               style: ElevatedButton.styleFrom(
                 padding: const EdgeInsets.symmetric(vertical: 16),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),
                 ),
-                backgroundColor: Colors.blue[600],
+                backgroundColor: AppColors.primary,
                 foregroundColor: Colors.white,
                 disabledBackgroundColor: Colors.grey[200],
               ),
               child: Text(
-                canSubmit ? '제출하기' : '모든 문제에 답해주세요',
+                isLast ? '제출하기' : '다음 문항',
                 style: const TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.bold,
@@ -529,7 +548,7 @@ class _ResultView extends StatelessWidget {
           width: double.infinity,
           padding: const EdgeInsets.all(24),
           decoration: BoxDecoration(
-            color: passed ? Colors.green[600] : Colors.orange[600],
+            color: passed ? AppColors.success : AppColors.accent,
           ),
           child: Column(
             children: [
@@ -594,10 +613,10 @@ class _ResultView extends StatelessWidget {
         Container(
           padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
           decoration: BoxDecoration(
-            color: Colors.white,
+            color: AppColors.surface,
             boxShadow: [
               BoxShadow(
-                color: Colors.black.withOpacity(0.06),
+                color: Colors.black.withOpacity(0.05),
                 blurRadius: 8,
                 offset: const Offset(0, -2),
               ),
@@ -619,7 +638,7 @@ class _ResultView extends StatelessWidget {
                     ),
                     style: ElevatedButton.styleFrom(
                       padding: const EdgeInsets.symmetric(vertical: 16),
-                      backgroundColor: Colors.green[600],
+                      backgroundColor: AppColors.success,
                       foregroundColor: Colors.white,
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(12),
@@ -631,7 +650,7 @@ class _ResultView extends StatelessWidget {
                     onPressed: onRetry,
                     style: ElevatedButton.styleFrom(
                       padding: const EdgeInsets.symmetric(vertical: 16),
-                      backgroundColor: Colors.blue[600],
+                      backgroundColor: AppColors.primary,
                       foregroundColor: Colors.white,
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(12),
@@ -646,9 +665,9 @@ class _ResultView extends StatelessWidget {
                   const SizedBox(height: 8),
                   TextButton(
                     onPressed: onClose,
-                    child: Text(
+                    child: const Text(
                       '나중에 하기',
-                      style: TextStyle(color: Colors.grey[600]),
+                      style: TextStyle(color: AppColors.textSecondary),
                     ),
                   ),
                 ],
@@ -676,12 +695,12 @@ class _ResultCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isCorrect = result?.isCorrect ?? false;
-    final color = isCorrect ? Colors.green : Colors.red;
+    final color = isCorrect ? AppColors.success : AppColors.danger;
 
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: AppColors.surface,
         borderRadius: BorderRadius.circular(14),
         border: Border.all(
           color: color.withOpacity(0.3),
@@ -689,7 +708,7 @@ class _ResultCard extends StatelessWidget {
         ),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.04),
+            color: Colors.black.withOpacity(0.03),
             blurRadius: 8,
             offset: const Offset(0, 2),
           ),
@@ -723,6 +742,7 @@ class _ResultCard extends StatelessWidget {
                     fontSize: 14,
                     fontWeight: FontWeight.w500,
                     height: 1.4,
+                    color: AppColors.textPrimary,
                   ),
                 ),
                 const SizedBox(height: 8),
@@ -768,7 +788,7 @@ class _AnswerChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = isCorrect ? Colors.green : Colors.red;
+    final color = isCorrect ? AppColors.success : AppColors.danger;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
       decoration: BoxDecoration(
@@ -780,7 +800,7 @@ class _AnswerChip extends StatelessWidget {
         '$label: $value',
         style: TextStyle(
           fontSize: 12,
-          color: color[700],
+          color: color,
           fontWeight: FontWeight.w600,
         ),
       ),
@@ -808,17 +828,17 @@ class _ErrorView extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.error_outline, size: 64, color: Colors.red[300]),
+            const Icon(Icons.error_outline, size: 64, color: AppColors.danger),
             const SizedBox(height: 20),
             const Text(
               '퀴즈를 불러오지 못했습니다',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: AppColors.textPrimary),
             ),
             const SizedBox(height: 8),
             Text(
               message,
               textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+              style: const TextStyle(fontSize: 12, color: AppColors.textSecondary),
             ),
             const SizedBox(height: 32),
             ElevatedButton.icon(
@@ -826,6 +846,8 @@ class _ErrorView extends StatelessWidget {
               icon: const Icon(Icons.refresh),
               label: const Text('다시 시도'),
               style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                foregroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
                 shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
               ),
@@ -833,7 +855,7 @@ class _ErrorView extends StatelessWidget {
             const SizedBox(height: 12),
             TextButton(
               onPressed: onClose,
-              child: Text('닫기', style: TextStyle(color: Colors.grey[600])),
+              child: const Text('닫기', style: TextStyle(color: AppColors.textSecondary)),
             ),
           ],
         ),
@@ -860,37 +882,39 @@ class _DailyLimitView extends StatelessWidget {
             Container(
               width: 80,
               height: 80,
-              decoration: BoxDecoration(
-                color: Colors.orange[50],
+              decoration: const BoxDecoration(
+                color: AppColors.accentLight,
                 shape: BoxShape.circle,
               ),
-              child: Icon(
+              child: const Icon(
                 Icons.hourglass_empty,
                 size: 40,
-                color: Colors.orange[600],
+                color: AppColors.accent,
               ),
             ),
             const SizedBox(height: 24),
             const Text(
               '오늘 응시 횟수 초과',
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: AppColors.textPrimary),
             ),
             const SizedBox(height: 12),
             Text(
               message,
               textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 15, color: Colors.grey[600], height: 1.5),
+              style: const TextStyle(fontSize: 15, color: AppColors.textSecondary, height: 1.5),
             ),
             const SizedBox(height: 8),
-            Text(
+            const Text(
               '내일 자정 이후 다시 도전할 수 있습니다.',
               textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 13, color: Colors.grey[500]),
+              style: TextStyle(fontSize: 13, color: AppColors.textSecondary),
             ),
             const SizedBox(height: 32),
             OutlinedButton(
               onPressed: onClose,
               style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.primary,
+                side: const BorderSide(color: AppColors.primary),
                 padding: const EdgeInsets.symmetric(
                     horizontal: 32, vertical: 14),
                 shape: RoundedRectangleBorder(

--- a/pentalk_front/lib/screens/student_home_screen.dart
+++ b/pentalk_front/lib/screens/student_home_screen.dart
@@ -3,7 +3,9 @@ import 'package:provider/provider.dart';
 import '../providers/student_session_provider.dart';
 import '../services/auth_service.dart';
 import '../widgets/student_session_card.dart';
+import '../theme/app_colors.dart';
 import 'material_list_screen.dart';
+import 'material_library_screen.dart';
 import 'login_screen.dart';
 import 'qr_scan_screen.dart';
 
@@ -17,6 +19,7 @@ class StudentHomeScreen extends StatefulWidget {
 class _StudentHomeScreenState extends State<StudentHomeScreen>
     with SingleTickerProviderStateMixin {
   TabController? _tabController;
+  int _tabIndex = 0;
 
   @override
   void initState() {
@@ -51,6 +54,38 @@ class _StudentHomeScreenState extends State<StudentHomeScreen>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.background,
+      body: IndexedStack(
+        index: _tabIndex,
+        children: [
+          _buildHomeTab(),
+          const MaterialLibraryScreen(isTeacher: false),
+        ],
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _tabIndex,
+        onDestinationSelected: (i) => setState(() => _tabIndex = i),
+        backgroundColor: AppColors.surface,
+        indicatorColor: AppColors.primaryLight,
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.home_outlined, color: AppColors.textSecondary),
+            selectedIcon: Icon(Icons.home, color: AppColors.primary),
+            label: '홈',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.folder_outlined, color: AppColors.textSecondary),
+            selectedIcon: Icon(Icons.folder, color: AppColors.primary),
+            label: '자료실',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHomeTab() {
+    return Scaffold(
+      backgroundColor: AppColors.background,
       appBar: AppBar(
         title: const Text(
           '서예영 님의 공간',
@@ -58,7 +93,7 @@ class _StudentHomeScreenState extends State<StudentHomeScreen>
         ),
         actions: [
           IconButton(
-            icon: const Icon(Icons.account_circle),
+            icon: const Icon(Icons.account_circle, color: AppColors.primary),
             onPressed: _handleSwitchRole,
             tooltip: '역할 변경',
           ),
@@ -76,13 +111,13 @@ class _StudentHomeScreenState extends State<StudentHomeScreen>
               _initializeTabController(provider.subjects);
 
               return Container(
-                color: Theme.of(context).colorScheme.surface,
+                color: AppColors.surface,
                 child: TabBar(
                   controller: _tabController,
                   isScrollable: true,
-                  labelColor: Theme.of(context).primaryColor,
-                  unselectedLabelColor: Colors.grey,
-                  indicatorColor: Theme.of(context).primaryColor,
+                  labelColor: AppColors.primary,
+                  unselectedLabelColor: AppColors.textSecondary,
+                  indicatorColor: AppColors.primary,
                   labelStyle: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.bold,
@@ -103,7 +138,9 @@ class _StudentHomeScreenState extends State<StudentHomeScreen>
             child: Consumer<StudentSessionProvider>(
               builder: (context, provider, child) {
                 if (provider.isLoading && provider.sessions.isEmpty) {
-                  return const Center(child: CircularProgressIndicator());
+                  return const Center(
+                    child: CircularProgressIndicator(color: AppColors.primary),
+                  );
                 }
 
                 if (provider.errorMessage != null) {
@@ -114,7 +151,7 @@ class _StudentHomeScreenState extends State<StudentHomeScreen>
                         const Icon(
                           Icons.error_outline,
                           size: 64,
-                          color: Colors.red,
+                          color: AppColors.danger,
                         ),
                         const SizedBox(height: 16),
                         Text(
@@ -127,6 +164,9 @@ class _StudentHomeScreenState extends State<StudentHomeScreen>
                           onPressed: () {
                             provider.loadMySessions();
                           },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: AppColors.primary,
+                          ),
                           child: const Text('다시 시도'),
                         ),
                       ],
@@ -139,25 +179,25 @@ class _StudentHomeScreenState extends State<StudentHomeScreen>
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Icon(
+                        const Icon(
                           Icons.school_outlined,
                           size: 80,
-                          color: Colors.grey[400],
+                          color: AppColors.textSecondary,
                         ),
                         const SizedBox(height: 16),
-                        Text(
+                        const Text(
                           '참여한 세션이 없습니다',
                           style: TextStyle(
                             fontSize: 18,
-                            color: Colors.grey[600],
+                            color: AppColors.textPrimary,
                           ),
                         ),
                         const SizedBox(height: 8),
-                        Text(
+                        const Text(
                           '교사가 공유한 QR 코드나 링크로 세션에 참여하세요',
                           style: TextStyle(
                             fontSize: 14,
-                            color: Colors.grey[500],
+                            color: AppColors.textSecondary,
                           ),
                           textAlign: TextAlign.center,
                         ),
@@ -195,9 +235,11 @@ class _StudentHomeScreenState extends State<StudentHomeScreen>
         if (index == 0) {
           // + 버튼 카드 (세션 추가용)
           return Card(
-            elevation: 2,
+            color: AppColors.surface,
+            elevation: 0,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
+              side: const BorderSide(color: AppColors.border),
             ),
             child: InkWell(
               onTap: () {
@@ -207,8 +249,8 @@ class _StudentHomeScreenState extends State<StudentHomeScreen>
                 );
               },
               borderRadius: BorderRadius.circular(12),
-              child: Center(
-                child: Icon(Icons.add, size: 48, color: Colors.grey[600]),
+              child: const Center(
+                child: Icon(Icons.add, size: 48, color: AppColors.primary),
               ),
             ),
           );

--- a/pentalk_front/lib/screens/teacher_home_screen.dart
+++ b/pentalk_front/lib/screens/teacher_home_screen.dart
@@ -6,7 +6,9 @@ import '../config/app_config.dart';
 import '../services/auth_service.dart';
 import '../widgets/session_card.dart';
 import '../widgets/create_session_dialog.dart';
+import '../theme/app_colors.dart';
 import 'session_detail_screen.dart';
+import 'material_library_screen.dart';
 import 'login_screen.dart';
 
 /// ===============================
@@ -22,6 +24,7 @@ class TeacherHomeScreen extends StatefulWidget {
 
 class _TeacherHomeScreenState extends State<TeacherHomeScreen> {
   String _userName = '선생님';
+  int _tabIndex = 0;
 
   @override
   void initState() {
@@ -82,6 +85,35 @@ class _TeacherHomeScreenState extends State<TeacherHomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.background,
+      body: IndexedStack(
+        index: _tabIndex,
+        children: [_buildHomeTab(), const MaterialLibraryScreen(isTeacher: true)],
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _tabIndex,
+        onDestinationSelected: (i) => setState(() => _tabIndex = i),
+        backgroundColor: AppColors.surface,
+        indicatorColor: AppColors.primaryLight,
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.home_outlined, color: AppColors.textSecondary),
+            selectedIcon: Icon(Icons.home, color: AppColors.primary),
+            label: '홈',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.folder_outlined, color: AppColors.textSecondary),
+            selectedIcon: Icon(Icons.folder, color: AppColors.primary),
+            label: '자료실',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHomeTab() {
+    return Scaffold(
+      backgroundColor: AppColors.background,
       appBar: AppBar(
         title: Text(
           '$_userName 님의 수업',
@@ -95,12 +127,15 @@ class _TeacherHomeScreenState extends State<TeacherHomeScreen> {
               tooltip: '로컬 PDF 테스트',
             ),
           IconButton(
-            icon: const Icon(Icons.add_circle_outline),
+            icon: const Icon(
+              Icons.add_circle_outline,
+              color: AppColors.primary,
+            ),
             onPressed: _showCreateSessionDialog,
             tooltip: '새 세션 만들기',
           ),
           IconButton(
-            icon: const Icon(Icons.account_circle),
+            icon: const Icon(Icons.account_circle, color: AppColors.primary),
             onPressed: _handleLogout,
             tooltip: '로그아웃',
           ),
@@ -109,7 +144,9 @@ class _TeacherHomeScreenState extends State<TeacherHomeScreen> {
       body: Consumer<SessionProvider>(
         builder: (context, provider, child) {
           if (provider.isLoading && provider.sessions.isEmpty) {
-            return const Center(child: CircularProgressIndicator());
+            return const Center(
+              child: CircularProgressIndicator(color: AppColors.primary),
+            );
           }
 
           if (provider.errorMessage != null) {
@@ -117,7 +154,11 @@ class _TeacherHomeScreenState extends State<TeacherHomeScreen> {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Icon(Icons.error_outline, size: 64, color: Colors.red),
+                  const Icon(
+                    Icons.error_outline,
+                    size: 64,
+                    color: AppColors.danger,
+                  ),
                   const SizedBox(height: 16),
                   Text(
                     provider.errorMessage!,
@@ -127,6 +168,9 @@ class _TeacherHomeScreenState extends State<TeacherHomeScreen> {
                   const SizedBox(height: 16),
                   ElevatedButton(
                     onPressed: provider.loadSessions,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                    ),
                     child: const Text('다시 시도'),
                   ),
                 ],
@@ -139,20 +183,33 @@ class _TeacherHomeScreenState extends State<TeacherHomeScreen> {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.folder_open, size: 80, color: Colors.grey[400]),
+                  const Icon(
+                    Icons.folder_open,
+                    size: 80,
+                    color: AppColors.textSecondary,
+                  ),
                   const SizedBox(height: 16),
-                  Text(
+                  const Text(
                     '아직 생성된 세션이 없습니다',
-                    style: TextStyle(fontSize: 18, color: Colors.grey[600]),
+                    style: TextStyle(
+                      fontSize: 18,
+                      color: AppColors.textPrimary,
+                    ),
                   ),
                   const SizedBox(height: 8),
-                  Text(
+                  const Text(
                     '우측 상단 + 버튼을 눌러 새 세션을 생성하세요',
-                    style: TextStyle(fontSize: 14, color: Colors.grey[500]),
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: AppColors.textSecondary,
+                    ),
                   ),
                   const SizedBox(height: 24),
                   ElevatedButton.icon(
                     onPressed: _showCreateSessionDialog,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                    ),
                     icon: const Icon(Icons.add),
                     label: const Text('새 세션 만들기'),
                   ),
@@ -173,24 +230,26 @@ class _TeacherHomeScreenState extends State<TeacherHomeScreen> {
             itemBuilder: (context, index) {
               if (index == 0) {
                 return Card(
-                  elevation: 2,
+                  color: AppColors.surface,
+                  elevation: 0,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
+                    side: const BorderSide(color: AppColors.border),
                   ),
                   child: InkWell(
                     onTap: _showCreateSessionDialog,
                     borderRadius: BorderRadius.circular(12),
-                    child: Center(
+                    child: const Center(
                       child: Column(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Icon(Icons.add, size: 48, color: Colors.grey[600]),
-                          const SizedBox(height: 8),
+                          Icon(Icons.add, size: 48, color: AppColors.primary),
+                          SizedBox(height: 8),
                           Text(
                             '새 세션',
                             style: TextStyle(
                               fontSize: 14,
-                              color: Colors.grey[600],
+                              color: AppColors.primary,
                             ),
                           ),
                         ],
@@ -230,7 +289,7 @@ class _TeacherHomeScreenState extends State<TeacherHomeScreen> {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
                           content: Text('삭제 실패: $e'),
-                          backgroundColor: Colors.red,
+                          backgroundColor: AppColors.danger,
                         ),
                       );
                     }

--- a/pentalk_front/lib/services/socket_service.dart
+++ b/pentalk_front/lib/services/socket_service.dart
@@ -19,6 +19,11 @@ class SocketService {
   bool _isRoomJoined = false;
   final List<Map<String, dynamic>> _pendingEmits = [];
 
+  // 인증 실패 시 캐시 토큰 갱신 후 1회 재연결하기 위한 상태
+  String? _lastServerUrl;
+  bool _authRetryInProgress = false;
+  bool _hasRetriedAuth = false;
+
   Function(DrawEvent)? onDrawEventReceived;
   Function(String)? onUserJoined;
   Function(String)? onUserLeft;
@@ -56,6 +61,7 @@ class SocketService {
     String? classId,
     String? materialId,
     int? pageNumber,
+    bool isInternalRetry = false,
     }) async {
     try {
       _currentUserId = userId;
@@ -66,6 +72,8 @@ class SocketService {
       _currentIsTeacher = isTeacher;
       _isRoomJoined = false;
       _pendingEmits.clear();
+      _lastServerUrl = serverUrl;
+      if (!isInternalRetry) _hasRetriedAuth = false;
 
       final normalizedUrl = _normalizeServerUrl(serverUrl);
       debugPrint('[socket] Connecting to $normalizedUrl');
@@ -126,6 +134,7 @@ class SocketService {
     required Uri uri,
     required String userId,
     required String role,
+    bool forceRefresh = false,
   }) async {
     final effectivePort = (uri.hasPort && uri.port > 0)
         ? uri.port
@@ -135,10 +144,16 @@ class SocketService {
     ].join(':');
 
     final prefs = await SharedPreferences.getInstance();
-    final cachedToken = prefs.getString(storageKey);
-    if (cachedToken != null && cachedToken.isNotEmpty) {
-      debugPrint('[socket][auth] using cached token role=$role userId=$userId');
-      return cachedToken;
+
+    if (forceRefresh) {
+      await prefs.remove(storageKey);
+      debugPrint('[socket][auth] cleared cached token role=$role userId=$userId');
+    } else {
+      final cachedToken = prefs.getString(storageKey);
+      if (cachedToken != null && cachedToken.isNotEmpty) {
+        debugPrint('[socket][auth] using cached token role=$role userId=$userId');
+        return cachedToken;
+      }
     }
 
     final authUri = Uri(
@@ -155,7 +170,61 @@ class SocketService {
     final token = decoded['token']?.toString() ?? '';
     if (token.isEmpty) throw Exception('dev-login token missing');
     await prefs.setString(storageKey, token);
+    debugPrint('[socket][auth] fetched fresh token role=$role userId=$userId');
     return token;
+  }
+
+  /// 캐시된 토큰이 서버에서 거부(UNAUTHORIZED)됐을 때 1회 한정으로
+  /// 토큰을 새로 발급받아 재연결한다.
+  bool _isAuthError(dynamic error) {
+    final text = error is Map ? error['message']?.toString() : error?.toString();
+    if (text == null) return false;
+    final normalized = text.toUpperCase();
+    return normalized.contains('UNAUTHORIZED') ||
+        normalized.contains('INVALID_TOKEN') ||
+        normalized.contains('JWT');
+  }
+
+  Future<void> _retryConnectionWithFreshToken() async {
+    final serverUrl = _lastServerUrl;
+    final userId = _currentUserId;
+    final roomId = _currentRoomId;
+    if (serverUrl == null || userId == null || roomId == null) return;
+    if (_authRetryInProgress || _hasRetriedAuth) return;
+
+    _authRetryInProgress = true;
+    _hasRetriedAuth = true;
+    debugPrint('[socket][auth] retrying connection with fresh token');
+
+    try {
+      final normalizedUrl = _normalizeServerUrl(serverUrl);
+      final uri = Uri.parse(normalizedUrl);
+      final role = _currentIsTeacher ? 'teacher' : 'student';
+      await _getOrCreateDevToken(
+        uri: uri,
+        userId: userId,
+        role: role,
+        forceRefresh: true,
+      );
+
+      _socket?.dispose();
+      _socket = null;
+
+      await connect(
+        serverUrl: serverUrl,
+        userId: userId,
+        roomId: roomId,
+        isTeacher: _currentIsTeacher,
+        classId: _currentClassId,
+        materialId: _currentMaterialId,
+        pageNumber: _currentPageNumber,
+        isInternalRetry: true,
+      );
+    } catch (e) {
+      debugPrint('[socket][auth] retry failed: $e');
+    } finally {
+      _authRetryInProgress = false;
+    }
   }
 
   void _setupEventListeners() {
@@ -180,10 +249,14 @@ class SocketService {
 
     _socket!.on('connect_error', (error) {
       debugPrint('[socket][error] connect_error: $error');
+      if (_isAuthError(error)) {
+        _retryConnectionWithFreshToken();
+      }
       onError?.call(error);
     });
 
     _socket!.on('draw:append', (data) {
+      debugPrint('[socket][recv] draw:append from=${data is Map ? data['userId'] : null}');
       try {
         onDrawEventReceived?.call(DrawEvent.fromJson(Map<String, dynamic>.from(data)));
       } catch (e) {
@@ -254,7 +327,12 @@ class SocketService {
       onError?.call(error);
     });
 
-    _socket!.on('error', (error) => onError?.call(error));
+    _socket!.on('error', (error) {
+      if (_isAuthError(error)) {
+        _retryConnectionWithFreshToken();
+      }
+      onError?.call(error);
+    });
 
     // Poll 이벤트
     _socket!.on('poll:start', (data) {
@@ -301,6 +379,7 @@ class SocketService {
 
     // Presence 이벤트
     _socket!.on('presence:state', (data) {
+      debugPrint('[socket][recv] presence:state: $data');
       if (data is! Map) return;
       final usersList = data['users'];
       if (usersList is! List) return;
@@ -310,6 +389,7 @@ class SocketService {
           .toList());
     });
     _socket!.on('presence:join', (data) {
+      debugPrint('[socket][recv] presence:join: $data');
       if (data is! Map) return;
       try {
         onPresenceJoin?.call(Participant.fromJson(Map<String, dynamic>.from(data)));
@@ -318,6 +398,7 @@ class SocketService {
       }
     });
     _socket!.on('presence:leave', (data) {
+      debugPrint('[socket][recv] presence:leave: $data');
       if (data is! Map) return;
       final userId = data['userId'] as String?;
       final role = data['role'] as String?;

--- a/pentalk_front/lib/theme/app_colors.dart
+++ b/pentalk_front/lib/theme/app_colors.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+/// ===============================
+/// PenTalk 앱 컬러 팔레트
+/// 인디고 포인트 + 아이보리 배경
+/// ===============================
+class AppColors {
+  AppColors._();
+
+  static const Color primary = Color(0xFF4F46E5); // 인디고
+  static const Color primaryLight = Color(0xFFEEF2FF);
+  static const Color accent = Color(0xFFF97316); // 오렌지
+  static const Color accentLight = Color(0xFFFCEFE0);
+
+  static const Color background = Color(0xFFFBF8EF); // 화면 배경 (아이보리)
+  static const Color surface = Color(0xFFFFFDF6); // 카드/입력창 배경
+  static const Color paper = Color(0xFFF3EEDD); // 판서 캔버스 종이
+
+  static const Color border = Color(0xFFEFE8D6);
+
+  static const Color textPrimary = Color(0xFF2B2A28);
+  static const Color textSecondary = Color(0xFFA39C8C);
+
+  static const Color success = Color(0xFF12A150);
+  static const Color danger = Color(0xFFEF4444);
+}

--- a/pentalk_front/lib/widgets/color_palette_bar.dart
+++ b/pentalk_front/lib/widgets/color_palette_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/drawing_provider.dart';
 import '../utils/pen_style_constants.dart';
+import '../theme/app_colors.dart';
 
 /// ===============================
 /// 색상 팔레트 바 (AppBar용)
@@ -18,7 +19,11 @@ class ColorPaletteBar extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             // 색상 아이콘 (인디케이터)
-            const Icon(Icons.palette, size: 18, color: Colors.grey),
+            const Icon(
+              Icons.palette,
+              size: 18,
+              color: AppColors.textSecondary,
+            ),
             const SizedBox(width: 4),
 
             // 색상 버튼들
@@ -48,7 +53,7 @@ class ColorPaletteBar extends StatelessWidget {
                         boxShadow: isSelected
                             ? [
                           BoxShadow(
-                            color: Colors.blue.withOpacity(0.5),
+                            color: AppColors.primary.withOpacity(0.5),
                             blurRadius: 4,
                             spreadRadius: 1,
                           )

--- a/pentalk_front/lib/widgets/poll_overlay.dart
+++ b/pentalk_front/lib/widgets/poll_overlay.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import '../models/poll_model.dart';
+import '../theme/app_colors.dart';
 
 /// ===============================
 /// 학생용 이해도 체크 오버레이
-/// 화면 하단에 표시
+/// 캔버스 중앙에 모달 카드로 표시
 /// ===============================
 class PollOverlay extends StatelessWidget {
   final PollState pollState;
@@ -21,125 +22,110 @@ class PollOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Positioned(
-      left: 0,
-      right: 0,
-      bottom: 80, // FAB 위에 표시
-      child: Center(
-        child: Container(
-          margin: const EdgeInsets.symmetric(horizontal: 24),
-          constraints: const BoxConstraints(maxWidth: 520),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(20),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withOpacity(0.15),
-                blurRadius: 20,
-                spreadRadius: 2,
-                offset: const Offset(0, 4),
-              ),
-            ],
-          ),
+    return Center(
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 24),
+        constraints: const BoxConstraints(maxWidth: 340),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(18),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.15),
+              blurRadius: 24,
+              spreadRadius: 2,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              // 헤더
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 20,
-                  vertical: 14,
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Text(
+                    '이해도 check!',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.textPrimary,
+                    ),
+                  ),
+                  if (pollState.hasDuration && pollState.isActive) ...[
+                    const SizedBox(width: 8),
+                    _TimerBadge(seconds: remainingSeconds),
+                  ],
+                  if (pollState.isAnswered && onDismiss != null) ...[
+                    const Spacer(),
+                    GestureDetector(
+                      onTap: onDismiss,
+                      child: const Icon(
+                        Icons.close,
+                        color: AppColors.textSecondary,
+                        size: 18,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                pollState.pollData!.question,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 13,
+                  color: AppColors.textSecondary,
+                  height: 1.4,
                 ),
-                decoration: BoxDecoration(
-                  color: Colors.blue[600],
-                  borderRadius: const BorderRadius.vertical(
-                    top: Radius.circular(20),
+              ),
+              const SizedBox(height: 16),
+
+              Row(
+                children: pollState.pollData!.options.map((option) {
+                  final isSelected = pollState.selectedOptionId == option.id;
+                  final isAnswered = pollState.isAnswered;
+
+                  return Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 4),
+                      child: _OptionButton(
+                        option: option,
+                        isSelected: isSelected,
+                        isDisabled: isAnswered,
+                        onTap: isAnswered ? null : () => onAnswer(option.id),
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
+
+              // 응답 완료 메시지
+              if (pollState.isAnswered)
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.check_circle,
+                        color: AppColors.success,
+                        size: 16,
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        '응답이 전송됐습니다',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: AppColors.success,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-                child: Row(
-                  children: [
-                    const Icon(Icons.poll, color: Colors.white, size: 20),
-                    const SizedBox(width: 8),
-                    const Expanded(
-                      child: Text(
-                        '이해도 체크',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 15,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                    // 타이머 (duration 있을 때만)
-                    if (pollState.hasDuration && pollState.isActive)
-                      _TimerBadge(seconds: remainingSeconds),
-                    // 답변 완료 후 닫기 버튼
-                    if (pollState.isAnswered && onDismiss != null)
-                      GestureDetector(
-                        onTap: onDismiss,
-                        child: const Icon(Icons.close, color: Colors.white, size: 20),
-                      ),
-                  ],
-                ),
-              ),
-
-              Padding(
-                padding: const EdgeInsets.all(20),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // 질문
-                    Text(
-                      pollState.pollData!.question,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w600,
-                        height: 1.4,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-
-                    // 선택지 버튼들
-                    ...pollState.pollData!.options.map((option) {
-                      final isSelected =
-                          pollState.selectedOptionId == option.id;
-                      final isAnswered = pollState.isAnswered;
-
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: 8),
-                        child: _OptionButton(
-                          option: option,
-                          isSelected: isSelected,
-                          isDisabled: isAnswered,
-                          onTap: isAnswered ? null : () => onAnswer(option.id),
-                        ),
-                      );
-                    }),
-
-                    // 응답 완료 메시지
-                    if (pollState.isAnswered)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 4),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Icon(Icons.check_circle,
-                                color: Colors.green[600], size: 16),
-                            const SizedBox(width: 6),
-                            Text(
-                              '응답이 전송됐습니다',
-                              style: TextStyle(
-                                fontSize: 13,
-                                color: Colors.green[700],
-                                fontWeight: FontWeight.w500,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                  ],
-                ),
-              ),
             ],
           ),
         ),
@@ -167,39 +153,33 @@ class _OptionButton extends StatelessWidget {
       duration: const Duration(milliseconds: 200),
       decoration: BoxDecoration(
         color: isSelected
-            ? Colors.blue[50]
+            ? AppColors.primaryLight
             : isDisabled
-            ? Colors.grey[50]
-            : Colors.white,
-        borderRadius: BorderRadius.circular(12),
+            ? Colors.grey[100]
+            : AppColors.background,
+        borderRadius: BorderRadius.circular(10),
         border: Border.all(
-          color: isSelected ? Colors.blue : Colors.grey[300]!,
-          width: isSelected ? 2 : 1,
+          color: isSelected ? AppColors.primary : AppColors.border,
+          width: isSelected ? 1.5 : 1,
         ),
       ),
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(10),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-          child: Row(
-            children: [
-              Expanded(
-                child: Text(
-                  option.text,
-                  style: TextStyle(
-                    fontSize: 15,
-                    color: isDisabled && !isSelected
-                        ? Colors.grey[400]
-                        : Colors.black87,
-                    fontWeight:
-                    isSelected ? FontWeight.bold : FontWeight.normal,
-                  ),
-                ),
-              ),
-              if (isSelected)
-                Icon(Icons.check_circle, color: Colors.blue[600], size: 20),
-            ],
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 12),
+          child: Text(
+            option.text,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 13,
+              color: isSelected
+                  ? AppColors.primary
+                  : isDisabled
+                  ? Colors.grey[400]
+                  : AppColors.textPrimary,
+              fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+            ),
           ),
         ),
       ),
@@ -219,7 +199,7 @@ class _TimerBadge extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
       decoration: BoxDecoration(
-        color: isUrgent ? Colors.red : Colors.white.withOpacity(0.25),
+        color: isUrgent ? AppColors.danger : AppColors.primaryLight,
         borderRadius: BorderRadius.circular(12),
       ),
       child: Row(
@@ -227,14 +207,14 @@ class _TimerBadge extends StatelessWidget {
         children: [
           Icon(
             Icons.timer,
-            color: Colors.white,
+            color: isUrgent ? Colors.white : AppColors.primary,
             size: 14,
           ),
           const SizedBox(width: 4),
           Text(
             '${seconds}s',
-            style: const TextStyle(
-              color: Colors.white,
+            style: TextStyle(
+              color: isUrgent ? Colors.white : AppColors.primary,
               fontSize: 13,
               fontWeight: FontWeight.bold,
             ),

--- a/pentalk_front/lib/widgets/poll_result_sheet.dart
+++ b/pentalk_front/lib/widgets/poll_result_sheet.dart
@@ -1,9 +1,12 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import '../models/poll_model.dart';
+import '../theme/app_colors.dart';
 
 /// ===============================
-/// 교사용 실시간 집계 결과 시트
-/// 화면 우측에 고정 표시
+/// 교사용 실시간 집계 결과 패널
+/// 판서 화면 좌측 고정 패널로 표시
 /// ===============================
 class PollResultSheet extends StatelessWidget {
   final PollState pollState;
@@ -17,237 +20,266 @@ class PollResultSheet extends StatelessWidget {
     required this.onClose,
   }) : super(key: key);
 
+  static const List<Color> _segmentColors = [
+    AppColors.primary,
+    AppColors.accent,
+    Color(0xFF9CA3AF),
+  ];
+
   @override
   Widget build(BuildContext context) {
     final result = pollState.resultData;
     final options = pollState.pollData?.options ?? [];
     final total = result?.total ?? 0;
+    final ratios = options
+        .map((option) => result?.ratioFor(option.id) ?? 0.0)
+        .toList();
 
-    return Positioned(
-      right: 16,
-      top: 16,
-      child: Container(
-        width: 280,
-        constraints: const BoxConstraints(maxHeight: 480),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.12),
-              blurRadius: 16,
-              spreadRadius: 1,
-              offset: const Offset(0, 4),
-            ),
-          ],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // 헤더
-            Container(
-              padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
-              decoration: BoxDecoration(
-                color: Colors.blue[600],
-                borderRadius: const BorderRadius.vertical(
-                  top: Radius.circular(16),
-                ),
-              ),
-              child: Row(
+    return Container(
+      color: AppColors.surface,
+      child: SafeArea(
+        left: false,
+        right: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
                 children: [
-                  const Icon(Icons.bar_chart, color: Colors.white, size: 18),
-                  const SizedBox(width: 8),
                   const Expanded(
                     child: Text(
-                      '이해도 집계',
+                      '현재 이해도 체크',
                       style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 14,
+                        fontSize: 13,
                         fontWeight: FontWeight.bold,
+                        color: AppColors.textPrimary,
                       ),
                     ),
                   ),
-                  // 타이머
                   if (pollState.hasDuration && pollState.isActive)
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 3),
-                      decoration: BoxDecoration(
-                        color: remainingSeconds <= 5
-                            ? Colors.red
-                            : Colors.white.withOpacity(0.25),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Text(
-                        '${remainingSeconds}s',
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 12,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                  // 종료 표시
-                  if (pollState.isEnded)
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 3),
-                      decoration: BoxDecoration(
-                        color: Colors.white.withOpacity(0.25),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: const Text(
-                        '종료',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 12,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                  // 닫기 버튼 (종료 시만)
+                    _TimerChip(seconds: remainingSeconds),
                   if (pollState.isEnded)
                     IconButton(
-                      icon: const Icon(Icons.close,
-                          color: Colors.white, size: 18),
+                      icon: const Icon(
+                        Icons.close,
+                        size: 18,
+                        color: AppColors.textSecondary,
+                      ),
                       onPressed: onClose,
                       padding: EdgeInsets.zero,
                       constraints: const BoxConstraints(
-                        minWidth: 32,
-                        minHeight: 32,
+                        minWidth: 28,
+                        minHeight: 28,
                       ),
                     ),
                 ],
               ),
-            ),
-
-            // 질문
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-              child: Text(
+              const SizedBox(height: 4),
+              Text(
                 pollState.pollData?.question ?? '',
                 style: const TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                  color: Colors.black87,
+                  fontSize: 12,
+                  color: AppColors.textSecondary,
                 ),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
               ),
-            ),
+              const SizedBox(height: 14),
 
-            // 응답자 수
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  Icon(Icons.people_outline,
-                      size: 14, color: Colors.grey[500]),
-                  const SizedBox(width: 4),
-                  Text(
-                    '응답 $total명',
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Colors.grey[500],
+              Center(
+                child: SizedBox(
+                  width: 110,
+                  height: 110,
+                  child: CustomPaint(
+                    painter: DonutChartPainter(
+                      ratios: ratios,
+                      colors: _segmentColors,
+                    ),
+                    child: Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            '$total명',
+                            style: const TextStyle(
+                              fontSize: 15,
+                              fontWeight: FontWeight.bold,
+                              color: AppColors.textPrimary,
+                            ),
+                          ),
+                          const Text(
+                            '응답',
+                            style: TextStyle(
+                              fontSize: 9,
+                              color: AppColors.textSecondary,
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 12),
-
-            // 선택지별 막대 그래프
-            if (options.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                child: Column(
-                  children: options.map((option) {
-                    final count = result?.countFor(option.id) ?? 0;
-                    final ratio = result?.ratioFor(option.id) ?? 0.0;
-
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 10),
-                      child: _ResultBar(
-                        text: option.text,
-                        count: count,
-                        ratio: ratio,
-                        total: total,
-                      ),
-                    );
-                  }).toList(),
                 ),
               ),
-          ],
+              const SizedBox(height: 14),
+
+              if (options.isNotEmpty)
+                Column(
+                  children: List.generate(options.length, (i) {
+                    final option = options[i];
+                    final count = result?.countFor(option.id) ?? 0;
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: _LegendRow(
+                        color: _segmentColors[i % _segmentColors.length],
+                        text: option.text,
+                        count: count,
+                      ),
+                    );
+                  }),
+                ),
+
+              const SizedBox(height: 8),
+              if (pollState.isActive)
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: onClose,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                    ),
+                    child: const Text(
+                      '이해도체크 종료',
+                      style: TextStyle(fontSize: 12),
+                    ),
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );
   }
 }
 
-class _ResultBar extends StatelessWidget {
+class _LegendRow extends StatelessWidget {
+  final Color color;
   final String text;
   final int count;
-  final double ratio;
-  final int total;
 
-  const _ResultBar({
+  const _LegendRow({
+    required this.color,
     required this.text,
     required this.count,
-    required this.ratio,
-    required this.total,
   });
 
   @override
   Widget build(BuildContext context) {
-    final percent = (ratio * 100).toStringAsFixed(0);
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+    return Row(
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Expanded(
-              child: Text(
-                text,
-                style: const TextStyle(
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-            const SizedBox(width: 8),
-            Text(
-              '$count명 ($percent%)',
-              style: TextStyle(
-                fontSize: 12,
-                color: Colors.grey[600],
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ],
+        Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
         ),
-        const SizedBox(height: 4),
-        ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: LinearProgressIndicator(
-            value: ratio,
-            minHeight: 10,
-            backgroundColor: Colors.grey[100],
-            valueColor: AlwaysStoppedAnimation<Color>(
-              _barColor(ratio),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            text,
+            style: const TextStyle(
+              fontSize: 11.5,
+              color: AppColors.textPrimary,
             ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
+        ),
+        Text(
+          '$count명',
+          style: const TextStyle(fontSize: 11, color: AppColors.textSecondary),
         ),
       ],
     );
   }
+}
 
-  Color _barColor(double ratio) {
-    if (ratio >= 0.7) return Colors.green;
-    if (ratio >= 0.4) return Colors.blue;
-    return Colors.orange;
+class _TimerChip extends StatelessWidget {
+  final int seconds;
+
+  const _TimerChip({required this.seconds});
+
+  @override
+  Widget build(BuildContext context) {
+    final isUrgent = seconds <= 5;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: isUrgent ? AppColors.danger : AppColors.primaryLight,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        '${seconds}s',
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.bold,
+          color: isUrgent ? Colors.white : AppColors.primary,
+        ),
+      ),
+    );
   }
+}
+
+/// ===============================
+/// 도넛차트 페인터 (외부 패키지 없이 CustomPaint로 구현)
+/// ===============================
+class DonutChartPainter extends CustomPainter {
+  final List<double> ratios;
+  final List<Color> colors;
+  final double strokeWidth;
+
+  DonutChartPainter({
+    required this.ratios,
+    required this.colors,
+    this.strokeWidth = 14,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = (size.shortestSide - strokeWidth) / 2;
+    final rect = Rect.fromCircle(center: center, radius: radius);
+
+    canvas.drawArc(
+      rect,
+      0,
+      2 * math.pi,
+      false,
+      Paint()
+        ..color = Colors.grey.shade200
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = strokeWidth,
+    );
+
+    double start = -math.pi / 2;
+    for (var i = 0; i < ratios.length; i++) {
+      final sweep = ratios[i] * 2 * math.pi;
+      if (sweep <= 0) continue;
+      canvas.drawArc(
+        rect,
+        start,
+        sweep,
+        false,
+        Paint()
+          ..color = colors[i % colors.length]
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = strokeWidth,
+      );
+      start += sweep;
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant DonutChartPainter oldDelegate) =>
+      oldDelegate.ratios != ratios || oldDelegate.colors != colors;
 }

--- a/pentalk_front/lib/widgets/quiz_editor_widget.dart
+++ b/pentalk_front/lib/widgets/quiz_editor_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/quiz_model.dart';
 import '../providers/quiz_provider.dart';
+import '../theme/app_colors.dart';
 
 /// ===============================
 /// 교사용 복습 퀴즈 관리 위젯
@@ -84,7 +85,7 @@ class _QuizEditorWidgetState extends State<QuizEditorWidget> {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
                   content: Text('오류: $e'),
-                  backgroundColor: Colors.red,
+                  backgroundColor: AppColors.danger,
                 ),
               );
             }
@@ -110,7 +111,7 @@ class _QuizEditorWidgetState extends State<QuizEditorWidget> {
           ElevatedButton(
             onPressed: () => Navigator.pop(context, true),
             style:
-            ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            ElevatedButton.styleFrom(backgroundColor: AppColors.danger),
             child: const Text('삭제'),
           ),
         ],
@@ -132,7 +133,7 @@ class _QuizEditorWidgetState extends State<QuizEditorWidget> {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text('삭제 실패: $e'),
-              backgroundColor: Colors.red,
+              backgroundColor: AppColors.danger,
             ),
           );
         }
@@ -157,12 +158,13 @@ class _QuizEditorWidgetState extends State<QuizEditorWidget> {
               child: Row(
                 children: [
                   const Icon(Icons.quiz_outlined,
-                      size: 22, color: Colors.blue),
+                      size: 22, color: AppColors.primary),
                   const SizedBox(width: 8),
                   const Text(
                     '복습 퀴즈',
                     style: TextStyle(
-                        fontSize: 18, fontWeight: FontWeight.bold),
+                        fontSize: 18, fontWeight: FontWeight.bold,
+                        color: AppColors.textPrimary),
                   ),
                   const Spacer(),
                   // 문항 수 뱃지
@@ -172,7 +174,7 @@ class _QuizEditorWidgetState extends State<QuizEditorWidget> {
                     decoration: BoxDecoration(
                       color: questions.length >= 3
                           ? Colors.grey[200]
-                          : Colors.blue[50],
+                          : AppColors.primaryLight,
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Text(
@@ -182,7 +184,7 @@ class _QuizEditorWidgetState extends State<QuizEditorWidget> {
                         fontWeight: FontWeight.bold,
                         color: questions.length >= 3
                             ? Colors.grey[600]
-                            : Colors.blue[700],
+                            : AppColors.primary,
                       ),
                     ),
                   ),
@@ -191,7 +193,7 @@ class _QuizEditorWidgetState extends State<QuizEditorWidget> {
                   if (provider.canAddQuestion)
                     IconButton(
                       icon: const Icon(Icons.add_circle_outline),
-                      color: Colors.blue,
+                      color: AppColors.primary,
                       tooltip: '문항 추가',
                       onPressed: _showAddDialog,
                     ),
@@ -300,7 +302,7 @@ class _QuestionTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final answer = question.answer ?? '?';
-    final answerColor = answer == 'O' ? Colors.green : Colors.red;
+    final answerColor = answer == 'O' ? AppColors.success : AppColors.danger;
 
     return ListTile(
       contentPadding:
@@ -308,16 +310,16 @@ class _QuestionTile extends StatelessWidget {
       leading: Container(
         width: 36,
         height: 36,
-        decoration: BoxDecoration(
-          color: Colors.blue[50],
+        decoration: const BoxDecoration(
+          color: AppColors.primaryLight,
           shape: BoxShape.circle,
         ),
         child: Center(
           child: Text(
             '${question.order}',
-            style: TextStyle(
+            style: const TextStyle(
               fontWeight: FontWeight.bold,
-              color: Colors.blue[700],
+              color: AppColors.primary,
             ),
           ),
         ),
@@ -344,7 +346,7 @@ class _QuestionTile extends StatelessWidget {
                 '정답: $answer',
                 style: TextStyle(
                   fontSize: 12,
-                  color: answerColor[700],
+                  color: answerColor,
                   fontWeight: FontWeight.bold,
                 ),
               ),
@@ -363,7 +365,7 @@ class _QuestionTile extends StatelessWidget {
           ),
           IconButton(
             icon: const Icon(Icons.delete_outline, size: 20),
-            color: Colors.red[400],
+            color: AppColors.danger,
             onPressed: onDelete,
             tooltip: '삭제',
           ),
@@ -429,7 +431,7 @@ class _QuestionEditDialogState extends State<_QuestionEditDialog> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
               content: Text('저장 실패: $e'),
-              backgroundColor: Colors.red),
+              backgroundColor: AppColors.danger),
         );
       }
     } finally {
@@ -476,7 +478,7 @@ class _QuestionEditDialogState extends State<_QuestionEditDialog> {
                 child: _OxSelectButton(
                   label: 'O',
                   isSelected: _selectedAnswer == 'O',
-                  color: Colors.green,
+                  color: AppColors.success,
                   onTap: () => setState(() => _selectedAnswer = 'O'),
                 ),
               ),
@@ -485,7 +487,7 @@ class _QuestionEditDialogState extends State<_QuestionEditDialog> {
                 child: _OxSelectButton(
                   label: 'X',
                   isSelected: _selectedAnswer == 'X',
-                  color: Colors.red,
+                  color: AppColors.danger,
                   onTap: () => setState(() => _selectedAnswer = 'X'),
                 ),
               ),

--- a/pentalk_front/lib/widgets/session_card.dart
+++ b/pentalk_front/lib/widgets/session_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../models/session_model.dart';
+import '../theme/app_colors.dart';
 import 'qr_view.dart';
 import 'package:intl/intl.dart';
 
@@ -34,8 +35,12 @@ class SessionCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      color: AppColors.surface,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: const BorderSide(color: AppColors.border),
+      ),
       child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(12),
@@ -53,13 +58,17 @@ class SessionCard extends StatelessWidget {
                       style: const TextStyle(
                         fontSize: 20,
                         fontWeight: FontWeight.bold,
+                        color: AppColors.textPrimary,
                       ),
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
                   if (onDelete != null)
                     IconButton(
-                      icon: const Icon(Icons.more_vert),
+                      icon: const Icon(
+                        Icons.more_vert,
+                        color: AppColors.textSecondary,
+                      ),
                       onPressed: () {
                         _showOptionsMenu(context);
                       },
@@ -72,24 +81,27 @@ class SessionCard extends StatelessWidget {
                   const Icon(
                     Icons.people_outline,
                     size: 16,
-                    color: Colors.grey,
+                    color: AppColors.textSecondary,
                   ),
                   const SizedBox(width: 4),
                   Text(
                     '최대 ${session.maxParticipants}명',
-                    style: const TextStyle(fontSize: 14, color: Colors.grey),
+                    style: const TextStyle(
+                      fontSize: 14,
+                      color: AppColors.textSecondary,
+                    ),
                   ),
                   const SizedBox(width: 16),
                   if (session.password != null) ...[
                     const Icon(
                       Icons.lock_outline,
                       size: 16,
-                      color: Colors.grey,
+                      color: AppColors.accent,
                     ),
                     const SizedBox(width: 4),
                     const Text(
                       '비밀번호 설정됨',
-                      style: TextStyle(fontSize: 14, color: Colors.grey),
+                      style: TextStyle(fontSize: 14, color: AppColors.accent),
                     ),
                   ],
                 ],
@@ -100,17 +112,23 @@ class SessionCard extends StatelessWidget {
                   const Icon(
                     Icons.folder_outlined,
                     size: 16,
-                    color: Colors.grey,
+                    color: AppColors.textSecondary,
                   ),
                   const SizedBox(width: 4),
                   Text(
                     '파일 ${session.files.length}개',
-                    style: const TextStyle(fontSize: 14, color: Colors.grey),
+                    style: const TextStyle(
+                      fontSize: 14,
+                      color: AppColors.textSecondary,
+                    ),
                   ),
                   const Spacer(),
                   Text(
                     _formatDate(session.createdAt),
-                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: AppColors.textSecondary,
+                    ),
                   ),
                 ],
               ),
@@ -142,8 +160,11 @@ class SessionCard extends StatelessWidget {
                   },
                 ),
               ListTile(
-                leading: const Icon(Icons.delete, color: Colors.red),
-                title: const Text('세션 삭제', style: TextStyle(color: Colors.red)),
+                leading: const Icon(Icons.delete, color: AppColors.danger),
+                title: const Text(
+                  '세션 삭제',
+                  style: TextStyle(color: AppColors.danger),
+                ),
                 onTap: () {
                   Navigator.pop(context);
                   _confirmDelete(context);
@@ -242,7 +263,9 @@ class SessionCard extends StatelessWidget {
                 Navigator.pop(context);
                 onDelete?.call();
               },
-              style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.danger,
+              ),
               child: const Text('삭제'),
             ),
           ],

--- a/pentalk_front/lib/widgets/student_session_card.dart
+++ b/pentalk_front/lib/widgets/student_session_card.dart
@@ -1,6 +1,7 @@
 
 import 'package:flutter/material.dart';
 import '../models/student_session_model.dart';
+import '../theme/app_colors.dart';
 
 class StudentSessionCard extends StatelessWidget {
   final StudentSessionModel session;
@@ -15,9 +16,11 @@ class StudentSessionCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 2,
+      color: AppColors.surface,
+      elevation: 0,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
+        side: const BorderSide(color: AppColors.border),
       ),
       child: InkWell(
         onTap: onTap,
@@ -33,6 +36,7 @@ class StudentSessionCard extends StatelessWidget {
                 style: const TextStyle(
                   fontSize: 24,
                   fontWeight: FontWeight.bold,
+                  color: AppColors.textPrimary,
                 ),
               ),
               const SizedBox(height: 8),
@@ -41,7 +45,7 @@ class StudentSessionCard extends StatelessWidget {
                   const Icon(
                     Icons.person_outline,
                     size: 16,
-                    color: Colors.grey,
+                    color: AppColors.textSecondary,
                   ),
                   const SizedBox(width: 4),
                   Expanded(
@@ -49,7 +53,7 @@ class StudentSessionCard extends StatelessWidget {
                       session.teacherName,
                       style: const TextStyle(
                         fontSize: 14,
-                        color: Colors.grey,
+                        color: AppColors.textSecondary,
                       ),
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -62,14 +66,14 @@ class StudentSessionCard extends StatelessWidget {
                   const Icon(
                     Icons.folder_outlined,
                     size: 16,
-                    color: Colors.grey,
+                    color: AppColors.textSecondary,
                   ),
                   const SizedBox(width: 4),
                   Text(
                     '자료 ${session.materials.length}개',
                     style: const TextStyle(
                       fontSize: 14,
-                      color: Colors.grey,
+                      color: AppColors.textSecondary,
                     ),
                   ),
                 ],

--- a/pentalk_front/lib/widgets/width_selector_bar.dart
+++ b/pentalk_front/lib/widgets/width_selector_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/drawing_provider.dart';
 import '../utils/pen_style_constants.dart';
+import '../theme/app_colors.dart';
 
 /// ===============================
 /// 굵기 선택 바 (AppBar용)
@@ -18,7 +19,11 @@ class WidthSelectorBar extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             // 굵기 아이콘 (인디케이터)
-            const Icon(Icons.line_weight, size: 18, color: Colors.grey),
+            const Icon(
+              Icons.line_weight,
+              size: 18,
+              color: AppColors.textSecondary,
+            ),
             const SizedBox(width: 4),
 
             // 굵기 버튼들
@@ -43,11 +48,13 @@ class WidthSelectorBar extends StatelessWidget {
                       ),
                       decoration: BoxDecoration(
                         color: isSelected
-                            ? Colors.blue.withOpacity(0.2)
+                            ? AppColors.primary.withOpacity(0.15)
                             : Colors.transparent,
                         borderRadius: BorderRadius.circular(4),
                         border: Border.all(
-                          color: isSelected ? Colors.blue : Colors.grey[300]!,
+                          color: isSelected
+                              ? AppColors.primary
+                              : Colors.grey[300]!,
                           width: isSelected ? 2 : 1,
                         ),
                       ),
@@ -69,8 +76,12 @@ class WidthSelectorBar extends StatelessWidget {
                             name,
                             style: TextStyle(
                               fontSize: 9,
-                              color: isSelected ? Colors.blue : Colors.grey[600],
-                              fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                              color: isSelected
+                                  ? AppColors.primary
+                                  : Colors.grey[600],
+                              fontWeight: isSelected
+                                  ? FontWeight.bold
+                                  : FontWeight.normal,
                             ),
                           ),
                         ],


### PR DESCRIPTION
## Summary
앱 전체 UI를 인디고+아이보리 톤으로 리디자인하고, 그 과정에서 발견된 학생 측 실시간 동기화 버그 3건을 수정했습니다.

## 변경 사항

### 🎨 UI 리디자인
- `theme/app_colors.dart` 신규 — 인디고(#4F46E5)/오렌지(#F97316)/아이보리 배경 색상 팔레트 중앙화, `main.dart` 테마 적용
- 교사/학생 홈 화면 색상 교체 + 하단 탭("홈"/"자료실") 추가
- `material_library_screen.dart` 신규 — 참여 중인 클래스의 자료를 모아보는 자료 보관함 화면
- 판서 화면(`drawing_screen.dart`) 전면 재구성 — 상단 AppBar 방식에서 좌측 아이콘 사이드바 + 상단바 + 툴바 구조로 전환
- 이해도체크 결과를 막대그래프 대신 도넛차트로 표시(`poll_result_sheet.dart`, 신규 `CustomPainter` 기반, 외부 패키지 없이 구현)
- 학생 이해도체크 팝업을 하단 고정에서 캔버스 중앙 모달 카드로 변경(`poll_overlay.dart`)
- 복습 퀴즈 화면을 전체 스크롤 방식에서 진행바 + 한 문제씩 진행 방식으로 변경(`quiz_screen.dart`)
- 자료 상세 화면에 퀴즈 통과/미통과에 따른 "필기 가능/읽기 전용" 잠금 배지 추가(`material_detail_screen.dart`)

### 🐛 버그 수정
1. **소켓 인증 토큰 미갱신** (`socket_service.dart`)
   캐시된 소켓 인증 토큰이 서버에서 거부(`UNAUTHORIZED`)돼도 갱신되지 않던 문제 수정 — 인증 실패 감지 시 토큰을 새로 발급받아 1회 자동 재연결하도록 개선.

2. **학생 참여 세션 기록 소실** (`student_session_provider.dart`)
   학생이 QR/코드로 세션에 정상 참여해도, 홈 화면에 돌아올 때마다 `loadMySessions()`가 참여 기록을 더미 데이터로 덮어써서 자료 보관함에 실제 클래스 자료가 조회되지 않던 문제 수정.

## Test
- `flutter analyze` 전체 통과 확인 (컴파일 에러 0건)
- 교사 로컬 판서 렌더링 정상 확인
- 교사↔교사(듀얼 테스트) 실시간 판서 동기화 정상 확인
- 학생 소켓 재연결 후 `join_success` 및 `draw:append` 수신 확인 필요 (서버 측 `NOT_CLASS_MEMBER` 이슈 별도 확인 중)
- 학생 자료 보관함 classId 추적 정상화 확인