### PR TITLE
fix: 자료 조회 API에 sessionId 파라미터 추가 (NOT_CLASS_MEMBER 403 해결)

### DIFF
--- a/pentalk_front/lib/screens/material_library_screen.dart
+++ b/pentalk_front/lib/screens/material_library_screen.dart
@@ -42,39 +42,38 @@ class _MaterialLibraryScreenState extends State<MaterialLibraryScreen> {
     });
 
     try {
-      final classIds = widget.isTeacher
-          ? context
-                .read<SessionProvider>()
-                .sessions
-                .map((s) => s.classId)
-                .whereType<String>()
-                .toSet()
-          : context
-                .read<StudentSessionProvider>()
-                .sessions
-                .map((s) => s.classId)
-                .whereType<String>()
-                .toSet();
+      // classId → sessionId (같은 classId가 여러 세션에 걸쳐 있으면 가장 먼저 발견된 세션 사용)
+      // sessionId는 ClassMember가 아닌 세션 참여자(QR/직접입력 입장)의 조회 권한 확인에 필요
+      final classIdToSessionId = <String, String>{};
+      if (widget.isTeacher) {
+        for (final s in context.read<SessionProvider>().sessions) {
+          final classId = s.classId;
+          if (classId == null || classId.isEmpty) continue;
+          classIdToSessionId.putIfAbsent(classId, () => s.id);
+        }
+      } else {
+        for (final s in context.read<StudentSessionProvider>().sessions) {
+          final classId = s.classId;
+          if (classId == null || classId.isEmpty) continue;
+          classIdToSessionId.putIfAbsent(classId, () => s.id);
+        }
+      }
 
       debugPrint(
         '📚 Material library: role=${widget.isTeacher ? "teacher" : "student"}, '
-        'classIds=$classIds',
+        'classIdToSessionId=$classIdToSessionId',
       );
-      if (!widget.isTeacher) {
-        final rawSessions = context.read<StudentSessionProvider>().sessions;
-        debugPrint(
-          '📚 StudentSessionProvider.sessions: '
-          '${rawSessions.map((s) => "(id=${s.id}, classId=${s.classId})").toList()}',
-        );
-      }
 
       final collected = <MaterialUploadResponse>[];
-      for (final classId in classIds) {
+      for (final entry in classIdToSessionId.entries) {
         try {
-          final items = await ApiService.getMaterials(classId: classId);
+          final items = await ApiService.getMaterials(
+            classId: entry.key,
+            sessionId: entry.value,
+          );
           collected.addAll(items);
         } catch (e) {
-          debugPrint('⚠️ 자료 조회 실패 (classId=$classId): $e');
+          debugPrint('⚠️ 자료 조회 실패 (classId=${entry.key}): $e');
         }
       }
 

--- a/pentalk_front/lib/screens/material_list_screen.dart
+++ b/pentalk_front/lib/screens/material_list_screen.dart
@@ -50,7 +50,10 @@ class _MaterialListScreenState extends State<MaterialListScreen> {
     materialProvider.setLoading(true);
 
     try {
-      final materials = await ApiService.getMaterials(classId: classId);
+      final materials = await ApiService.getMaterials(
+        classId: classId,
+        sessionId: widget.sessionId,
+      );
       if (!mounted) return;
 
       materialProvider.setMaterials(

--- a/pentalk_front/lib/screens/session_detail_screen.dart
+++ b/pentalk_front/lib/screens/session_detail_screen.dart
@@ -193,7 +193,10 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
     materialProvider.setLoading(true);
 
     try {
-      final materials = await ApiService.getMaterials(classId: classId);
+      final materials = await ApiService.getMaterials(
+        classId: classId,
+        sessionId: _effectiveSessionId ?? widget.sessionId,
+      );
       if (!mounted) return;
 
       materialProvider.setMaterials(

--- a/pentalk_front/lib/services/api_service.dart
+++ b/pentalk_front/lib/services/api_service.dart
@@ -770,18 +770,28 @@ class ApiService {
   }
 
   /// ===============================
-  /// 자료 목록 조회 (GET /materials?classId=)
+  /// 자료 목록 조회 (GET /materials?classId=&sessionId=)
+  /// sessionId: ClassMember가 아닌 세션 참여자(QR/직접입력 입장)의 조회 권한 확인용
   /// ===============================
   static Future<List<MaterialUploadResponse>> getMaterials({
     required String classId,
+    String? sessionId,
   }) async {
     final token = await AuthService.getToken();
 
-    debugPrint('📥 GET /materials?classId=$classId');
+    final queryParams = {
+      'classId': classId,
+      if (sessionId != null && sessionId.isNotEmpty) 'sessionId': sessionId,
+    };
+    final uri = Uri.parse(
+      '$baseUrl/materials',
+    ).replace(queryParameters: queryParams);
+
+    debugPrint('📥 GET $uri');
 
     final response = await http
         .get(
-          Uri.parse('$baseUrl/materials?classId=$classId'),
+          uri,
           headers: {
             'Content-Type': 'application/json',
             if (token != null) 'Authorization': 'Bearer $token',


### PR DESCRIPTION
## Summary
QR/직접입력으로 세션에 입장한 학생이 자료 보관함 조회 시 `403 NOT_CLASS_MEMBER`를 받던 문제를 해결했습니다. 서버가 `GET /materials`의 권한 확인 방식을 ClassMember 기반에서 세션 참여자 기반으로 변경하면서, 요청 시 `sessionId`를 함께 전달해야 하도록 API 스펙이 바뀌어 프론트도 함께 대응했습니다.

## 변경 사항
- `api_service.dart`: `getMaterials()`에 `sessionId` 파라미터 추가, 쿼리스트링에 포함 (`GET /materials?classId=&sessionId=`)
- `material_library_screen.dart`: classId만 모으던 방식에서 classId→sessionId 매핑으로 변경해 조회 시 함께 전달
- `session_detail_screen.dart`, `material_list_screen.dart`: 동일하게 `sessionId` 파라미터 전달하도록 수정

## Test
- 학생이 QR/직접입력으로 세션 참여 후 자료 보관함 진입 → `403` 없이 실제 업로드된 자료 정상 조회 확인 (`Materials loaded: 1개`)
- 기존 더미 클래스(seed-class-01) 조회도 정상 동작 확인