### PR TITLE
feat: 학생 질문하기및 익명 질문 기능 추가

### DIFF
--- a/pentalk_front/lib/main.dart
+++ b/pentalk_front/lib/main.dart
@@ -10,6 +10,7 @@ import 'providers/personal_drawing_provider.dart';
 import 'providers/participants_provider.dart';
 import 'providers/material_provider.dart';
 import 'providers/quiz_provider.dart';
+import 'providers/question_provider.dart';
 import 'screens/join_session_screen.dart';
 import 'screens/splash_screen.dart';
 import 'services/deep_link_service.dart';
@@ -41,6 +42,7 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => PollProvider()),
         ChangeNotifierProvider(create: (_) => MaterialProvider()),
         ChangeNotifierProvider(create: (_) => QuizProvider()),
+        ChangeNotifierProvider(create: (_) => QuestionProvider()),
       ],
       child: MaterialApp(
         title: '하이브리드 교실',

--- a/pentalk_front/lib/models/question_model.dart
+++ b/pentalk_front/lib/models/question_model.dart
@@ -1,0 +1,45 @@
+/// ===============================
+/// 질문하기(Q&A) 모델
+/// 학생 → 교사 단방향 질문. 교사는 답장 불가, 발신자 식별 불가(익명)
+/// ===============================
+class QuestionModel {
+  final String id;
+  final String content;
+  final DateTime createdAt;
+
+  const QuestionModel({
+    required this.id,
+    required this.content,
+    required this.createdAt,
+  });
+
+  /// 서버 실제 페이로드: { questionId, content, askedBy, status, askedAt(epoch ms) }
+  /// 발신자 식별 정보(askedBy)는 서버가 익명일 때 항상 null로 치환해 내려주므로
+  /// 여기서도 의도적으로 파싱하지 않는다 (항상 익명).
+  factory QuestionModel.fromJson(Map<String, dynamic> json) {
+    final rawId = json['questionId'] ?? json['id'];
+    final rawContent = json['content'] ?? json['question'] ?? json['text'];
+    final rawAskedAt = json['askedAt'] ?? json['createdAt'] ?? json['timestamp'];
+
+    DateTime parsedDate;
+    if (rawAskedAt is int) {
+      parsedDate = DateTime.fromMillisecondsSinceEpoch(rawAskedAt);
+    } else if (rawAskedAt is String) {
+      // epoch ms가 문자열로 오는 경우도 방어
+      final asInt = int.tryParse(rawAskedAt);
+      parsedDate = asInt != null
+          ? DateTime.fromMillisecondsSinceEpoch(asInt)
+          : (DateTime.tryParse(rawAskedAt) ?? DateTime.now());
+    } else {
+      parsedDate = DateTime.now();
+    }
+
+    return QuestionModel(
+      id:
+          rawId?.toString() ??
+          DateTime.now().microsecondsSinceEpoch.toString(),
+      content: rawContent?.toString() ?? '',
+      createdAt: parsedDate,
+    );
+  }
+}

--- a/pentalk_front/lib/providers/question_provider.dart
+++ b/pentalk_front/lib/providers/question_provider.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import '../models/question_model.dart';
+
+/// ===============================
+/// 질문하기(Q&A) Provider — 교사 전용 수신함
+/// ===============================
+class QuestionProvider extends ChangeNotifier {
+  final List<QuestionModel> _questions = [];
+
+  List<QuestionModel> get questions => List.unmodifiable(_questions);
+  int get unreadCount => _questions.length;
+
+  void addQuestion(QuestionModel question) {
+    if (_questions.any((q) => q.id == question.id)) return;
+    _questions.insert(0, question);
+    notifyListeners();
+  }
+
+  void setQuestions(List<QuestionModel> questions) {
+    _questions
+      ..clear()
+      ..addAll(questions);
+    notifyListeners();
+  }
+
+  void dismiss(String id) {
+    _questions.removeWhere((q) => q.id == id);
+    notifyListeners();
+  }
+
+  void clear() {
+    _questions.clear();
+    notifyListeners();
+  }
+}

--- a/pentalk_front/lib/screens/drawing_screen.dart
+++ b/pentalk_front/lib/screens/drawing_screen.dart
@@ -6,12 +6,14 @@ import 'package:provider/provider.dart';
 import '../models/document_source.dart';
 import '../models/student_session_model.dart';
 import '../models/poll_model.dart';
+import '../models/question_model.dart';
 import '../config/app_config.dart';
 import '../native_drawing.dart';
 import '../providers/drawing_provider.dart';
 import '../providers/personal_drawing_provider.dart';
 import '../providers/participants_provider.dart';
 import '../providers/poll_provider.dart';
+import '../providers/question_provider.dart';
 import '../widgets/drawing_canvas_widget.dart';
 import '../widgets/session_ended_dialog.dart';
 import '../widgets/participants_button.dart';
@@ -23,6 +25,8 @@ import '../widgets/poll_result_sheet.dart';
 import '../widgets/poll_start_dialog.dart';
 import '../widgets/qr_view.dart';
 import '../widgets/quiz_editor_widget.dart';
+import '../widgets/questions_panel.dart';
+import '../widgets/question_ask_dialog.dart';
 import '../services/api_service.dart';
 import '../services/deep_link_service.dart';
 import '../services/pdf_document_service.dart';
@@ -85,6 +89,9 @@ class _DrawingScreenState extends State<DrawingScreen> {
   /// 학생이 이해도 체크에 답변 후 팝업을 수동으로 닫은 상태
   bool _pollOverlayDismissed = false;
 
+  /// 교사: 질문 패널 표시 여부 (로컬 UI 토글)
+  bool _showQuestionsPanel = false;
+
   bool get _usesNativeTeacherDrawing =>
       AppConfig.enableNativeTeacherDrawing &&
       !kIsWeb &&
@@ -109,6 +116,7 @@ class _DrawingScreenState extends State<DrawingScreen> {
       _setupSessionEndedListener();
       _setupPresenceCallbacks();
       _setupPollCallbacks();
+      _setupQuestionCallbacks();
     });
   }
 
@@ -590,6 +598,57 @@ class _DrawingScreenState extends State<DrawingScreen> {
     debugPrint('Presence callbacks setup completed');
   }
 
+  /// ===============================
+  /// 질문하기(Q&A) 콜백 설정
+  /// 교사: 새 질문 수신 / 학생: 전송 확인
+  /// ===============================
+  void _setupQuestionCallbacks() {
+    final socketService = _drawingProvider.socketService;
+
+    if (widget.isTeacher) {
+      final questionProvider = context.read<QuestionProvider>();
+
+      socketService.onQuestionNew = (data) {
+        questionProvider.addQuestion(QuestionModel.fromJson(data));
+      };
+
+      socketService.onQuestionListResult = (data) {
+        final questions = data
+            .whereType<Map>()
+            .map((e) => QuestionModel.fromJson(Map<String, dynamic>.from(e)))
+            .toList();
+        questionProvider.setQuestions(questions);
+      };
+
+      // 재입장 시 기존에 쌓인 질문 목록 요청
+      socketService.requestQuestionList();
+    } else {
+      socketService.onQuestionAck = (data) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('질문이 전송됐습니다')));
+      };
+    }
+
+    debugPrint('Question callbacks setup completed');
+  }
+
+  /// ===============================
+  /// 학생: 질문하기 다이얼로그
+  /// ===============================
+  void _openAskQuestionDialog() {
+    QuestionAskDialog.show(
+      context,
+      onSend: (content) {
+        _drawingProvider.socketService.askQuestion(
+          content: content,
+          isAnonymous: true,
+        );
+      },
+    );
+  }
+
   void _handleSessionEnded(Map<String, dynamic> data) {
     final message = data['message'] as String? ?? '교사가 수업을 종료했습니다';
 
@@ -627,6 +686,9 @@ class _DrawingScreenState extends State<DrawingScreen> {
   void _cleanupAndGoHome() {
     _drawingProvider.disconnectSocket();
     _drawingProvider.clear();
+    if (widget.isTeacher) {
+      context.read<QuestionProvider>().clear();
+    }
     Navigator.of(context).pushAndRemoveUntil(
       MaterialPageRoute(
         builder: (_) => widget.isTeacher
@@ -879,6 +941,27 @@ class _DrawingScreenState extends State<DrawingScreen> {
                 label: '복습퀴즈',
                 isActive: false,
                 onTap: _openQuizEditor,
+              ),
+            if (widget.isTeacher)
+              Consumer<QuestionProvider>(
+                builder: (context, questionProvider, _) {
+                  return _SidebarNavItem(
+                    icon: Icons.chat_bubble_outline,
+                    label: '질문들',
+                    isActive: _showQuestionsPanel,
+                    badgeCount: questionProvider.unreadCount,
+                    onTap: () => setState(
+                      () => _showQuestionsPanel = !_showQuestionsPanel,
+                    ),
+                  );
+                },
+              ),
+            if (!widget.isTeacher)
+              _SidebarNavItem(
+                icon: Icons.chat_bubble_outline,
+                label: '질문하기',
+                isActive: false,
+                onTap: _openAskQuestionDialog,
               ),
             const SizedBox(height: 4),
             const ParticipantsButton(),
@@ -1169,6 +1252,20 @@ class _DrawingScreenState extends State<DrawingScreen> {
                         );
                       },
                     ),
+
+                  // 교사: 질문 수신함 좌측 고정 패널
+                  if (widget.isTeacher && _showQuestionsPanel)
+                    SizedBox(
+                      width: 170,
+                      child: Consumer<QuestionProvider>(
+                        builder: (context, questionProvider, _) {
+                          return QuestionsPanel(
+                            questions: questionProvider.questions,
+                            onDismiss: questionProvider.dismiss,
+                          );
+                        },
+                      ),
+                    ),
                 ],
               ),
         floatingActionButton: widget.isReadOnly
@@ -1388,6 +1485,7 @@ class _SidebarNavItem extends StatelessWidget {
   final String label;
   final bool isActive;
   final bool isDanger;
+  final int? badgeCount;
   final VoidCallback onTap;
 
   const _SidebarNavItem({
@@ -1396,6 +1494,7 @@ class _SidebarNavItem extends StatelessWidget {
     required this.isActive,
     required this.onTap,
     this.isDanger = false,
+    this.badgeCount,
   });
 
   @override
@@ -1413,14 +1512,46 @@ class _SidebarNavItem extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Container(
-              width: 32,
-              height: 32,
-              decoration: BoxDecoration(
-                color: isActive ? AppColors.primaryLight : Colors.transparent,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Icon(icon, size: 18, color: color),
+            Stack(
+              clipBehavior: Clip.none,
+              children: [
+                Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: isActive
+                        ? AppColors.primaryLight
+                        : Colors.transparent,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Icon(icon, size: 18, color: color),
+                ),
+                if (badgeCount != null && badgeCount! > 0)
+                  Positioned(
+                    top: -3,
+                    right: -3,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 4,
+                        vertical: 1,
+                      ),
+                      constraints: const BoxConstraints(minWidth: 14),
+                      decoration: const BoxDecoration(
+                        color: AppColors.accent,
+                        shape: BoxShape.circle,
+                      ),
+                      child: Text(
+                        badgeCount! > 9 ? '9+' : '$badgeCount',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          fontSize: 8,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
             ),
             const SizedBox(height: 2),
             Text(

--- a/pentalk_front/lib/widgets/question_ask_dialog.dart
+++ b/pentalk_front/lib/widgets/question_ask_dialog.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
+
+/// ===============================
+/// 학생용 질문하기 작성 다이얼로그
+/// 항상 익명으로 전송됨 (교사는 발신자를 알 수 없음)
+/// ===============================
+class QuestionAskDialog extends StatefulWidget {
+  final void Function(String content) onSend;
+
+  const QuestionAskDialog({Key? key, required this.onSend}) : super(key: key);
+
+  static Future<void> show(
+    BuildContext context, {
+    required void Function(String content) onSend,
+  }) {
+    return showDialog(
+      context: context,
+      builder: (context) => QuestionAskDialog(onSend: onSend),
+    );
+  }
+
+  @override
+  State<QuestionAskDialog> createState() => _QuestionAskDialogState();
+}
+
+class _QuestionAskDialogState extends State<QuestionAskDialog> {
+  static const int _maxLength = 500; // 서버 제한(content 최대 500자)에 맞춤
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleSend() {
+    final content = _controller.text.trim();
+    if (content.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('질문 내용을 입력해주세요')));
+      return;
+    }
+    Navigator.pop(context);
+    widget.onSend(content);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      title: const Row(
+        children: [
+          Icon(Icons.chat_bubble_outline, color: AppColors.primary),
+          SizedBox(width: 8),
+          Text('질문하기'),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '익명으로 전송돼요. 선생님은 누가 보냈는지 알 수 없어요.',
+            style: TextStyle(fontSize: 12.5, color: AppColors.textSecondary),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _controller,
+            autofocus: true,
+            maxLines: 5,
+            minLines: 2,
+            maxLength: _maxLength,
+            decoration: InputDecoration(
+              hintText: '예: 방금 설명하신 부분 다시 알려주실 수 있나요?',
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('취소'),
+        ),
+        ElevatedButton(
+          onPressed: _handleSend,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            foregroundColor: Colors.white,
+          ),
+          child: const Text('전송'),
+        ),
+      ],
+    );
+  }
+}

--- a/pentalk_front/lib/widgets/questions_panel.dart
+++ b/pentalk_front/lib/widgets/questions_panel.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../models/question_model.dart';
+import '../theme/app_colors.dart';
+
+/// ===============================
+/// 교사용 학생 질문 수신함 패널
+/// 판서 화면 좌측 고정 패널로 표시
+/// 익명 수신 전용 — 발신자 정보 없음, 답장 불가
+/// ===============================
+class QuestionsPanel extends StatelessWidget {
+  final List<QuestionModel> questions;
+  final ValueChanged<String> onDismiss;
+
+  const QuestionsPanel({
+    Key? key,
+    required this.questions,
+    required this.onDismiss,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.surface,
+      child: SafeArea(
+        left: false,
+        right: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+              child: Text(
+                '학생 질문 · ${questions.length}',
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.textPrimary,
+                ),
+              ),
+            ),
+            Expanded(
+              child: questions.isEmpty
+                  ? const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Text(
+                        '아직 받은 질문이 없습니다',
+                        style: TextStyle(
+                          fontSize: 11.5,
+                          color: AppColors.textSecondary,
+                        ),
+                      ),
+                    )
+                  : ListView.separated(
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
+                      itemCount: questions.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 8),
+                      itemBuilder: (context, index) {
+                        final q = questions[index];
+                        return _QuestionBubble(
+                          question: q,
+                          onDismiss: () => onDismiss(q.id),
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _QuestionBubble extends StatelessWidget {
+  final QuestionModel question;
+  final VoidCallback onDismiss;
+
+  const _QuestionBubble({required this.question, required this.onDismiss});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: AppColors.background,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  question.content,
+                  style: const TextStyle(
+                    fontSize: 11.5,
+                    color: AppColors.textPrimary,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+              GestureDetector(
+                onTap: onDismiss,
+                child: const Padding(
+                  padding: EdgeInsets.only(left: 4),
+                  child: Icon(
+                    Icons.close,
+                    size: 14,
+                    color: AppColors.textSecondary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            DateFormat('HH:mm').format(question.createdAt),
+            style: const TextStyle(
+              fontSize: 9.5,
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
학생이 교사에게 익명으로 질문을 보낼 수 있는 '질문하기' 기능을 추가했습니다. 교사는 질문을 받기만 할 뿐 답장할 수 없고, 누가 보냈는지도 알 수 없습니다.

## 변경 사항
- `models/question_model.dart`  — 질문 데이터 모델. 서버 페이로드(`questionId`, `content`, `askedAt` epoch ms)를 파싱하며, 발신자 식별 정보(`askedBy`)는 의도적으로 파싱하지 않음
- `providers/question_provider.dart`  — 교사 측 질문 수신함 상태 관리 (수신/닫기/초기화)
- `widgets/question_ask_dialog.dart`  — 학생용 질문 작성 다이얼로그 (최대 500자, 익명 안내 문구 포함)
- `widgets/questions_panel.dart`  — 교사용 질문 목록 패널, 질문별 확인/닫기 가능
- `screens/drawing_screen.dart`
  - 교사 사이드바에 "질문들" 항목 추가 (안읽은 개수 뱃지, 클릭 시 좌측 고정 패널 토글)
  - 학생 사이드바에 "질문하기" 항목 추가
  - 소켓 콜백 연결: `onQuestionNew`(신규 질문 수신), `onQuestionListResult`(재입장 시 목록 동기화), `onQuestionAck`(전송 확인 토스트)
  - 세션 종료 시 교사의 질문 목록 초기화
- `main.dart` — `QuestionProvider` 전역 등록

## Test
- 학생이 질문 전송 → "질문이 전송됐습니다" 토스트 확인
- 교사 사이드바 "질문들" 아이콘에 뱃지 카운트 표시 확인
- 교사가 패널에서 질문 내용 확인 및 개별 질문 닫기(X) 동작 확인
- 질문에 발신자 정보가 전혀 표시되지 않는지(익명성) 확인
